### PR TITLE
in code block, use file extension to set language for syntax highlighting

### DIFF
--- a/src/blocks/file-blocks/code/index.tsx
+++ b/src/blocks/file-blocks/code/index.tsx
@@ -1,15 +1,26 @@
 import "./style.css"
 import SyntaxHighlighter from "react-syntax-highlighter";
-// import { FileBlockProps } from "@githubnext/utils";
+import { FileBlockProps } from "@githubnext/utils";
 
-export default function (props: any) {
-  const { content } = props;
+function languageOfExtension(extension?: string) {
+  switch (extension) {
+    case undefined: return "text";
+    case "jsx": return "javascript";
+    case "tsx": return "typescript";
+    default: return extension;
+  }
+}
+
+export default function (props: FileBlockProps) {
+  const { content, context: { path } } = props;
+
+  const extension = path.includes(".") ? path.split(".").pop() : undefined;
+  const language = languageOfExtension(extension);
 
   return (
     <div className="code">
       <SyntaxHighlighter
-        // TODO: pass in language here with a utility function
-        language={''}
+        language={language}
         useInlineStyles={false}
         showLineNumbers
         lineNumberStyle={{ opacity: 0.45 }}


### PR DESCRIPTION
The default HighlightJS highlighter claims not to support JSX / TSX but it seems to work OK to translate `jsx`/`tsx` to `javascript`/`typescript`. I tried the PrismJS highlighter (which supposedly supports them) but it didn't work out of the box (no highlighting at all) and I didn't spend any time trying to debug it.

(I saw the `getLanguageFromFilename` function in `utils`; it returns a language label by extension, not a HighlightJS language tag.)

<img width="961" alt="Screen Shot 2022-02-25 at 5 13 02 PM" src="https://user-images.githubusercontent.com/56439/155823059-3711e2b9-4f7b-4627-9c01-38ca401e15a8.png">
