### PR TITLE
fix CodeSandbox infinite loop and missing import

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "@excalidraw/excalidraw": "^0.10.0",
     "@fullstackio/cq": "^6.0.9",
     "@fullstackio/remark-cq": "^6.1.2",
-    "@githubnext/utils": "^0.15.3",
+    "@githubnext/utils": "^0.15.4",
     "@githubocto/flat-ui": "^0.13.4",
     "@loadable/component": "^5.15.0",
     "@octokit/rest": "^18.12.0",

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -73,6 +73,10 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
 
   if (!bundleCode) return null;
 
+  const filesWithConfig = { ...files,
+    '/sandbox.config.json': JSON.stringify({ infiniteLoopProtection: false })
+  };
+
   return (
     <div
       ref={sandpackWrapper}
@@ -86,7 +90,7 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
         template="react"
         customSetup={{
           dependencies: {},
-          files: files,
+          files: filesWithConfig,
         }}
         autorun
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -633,10 +633,10 @@
     unist-util-visit "^1.0.0"
     uuid "^3.3.2"
 
-"@githubnext/utils@^0.15.3":
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.15.3.tgz#2d13e6898a0233b3cb6d3f280153bce9225021bf"
-  integrity sha512-YR8zLWrjoyEe6AdeS/BAWpUbxF2gZuahekSQdT6o1Yh15I9S69qs1d0QGdiLrK7M3hfER3ya8jpy5F+H2oiHlg==
+"@githubnext/utils@^0.15.4":
+  version "0.15.4"
+  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.15.4.tgz#24010abb242193b89be5968b4d17e8731ae52755"
+  integrity sha512-Oi6SixqnjLW+sNNqPKe5WJ8hbj3ODDVfR5Cu3Oy6EUYEKZeGF68fk+g7mDJDKYof3k2+dKOb8Pnw8UNgjzHJjw==
   dependencies:
     "@types/lodash.uniqueid" "^4.0.6"
     git-url-parse "^11.6.0"


### PR DESCRIPTION
bump `utils` to pick up https://github.com/githubnext/utils/pull/7, and disable `infiniteLoopProtection` in CodeSandbox, which causes a `Potential infinite loop: exceeded 10001 iterations` on pre-bundled nested CodeSandbox instances.

@mattrothenberg I'm going to put your CSS changes in a separate PR