### PR TITLE
make CodeSandbox iframe full-height with nested CodeSandboxes

### DIFF
--- a/src/blocks/file-blocks/annotate-react/style.css
+++ b/src/blocks/file-blocks/annotate-react/style.css
@@ -1,4 +1,10 @@
-.sp-loading:before {
+.sp-preview-iframe {
+  outline: none;
+  width: 100%;
+  border: none;
+}
+
+.sandbox-wrapper .sp-loading:before {
   content: "Loading...";
   position: absolute;
   top: 30%;
@@ -7,16 +13,4 @@
   opacity: 0.5;
   transform: translate(-50%, -50%);
   font-style: italic;
-}
-.sp-preview-iframe {
-  outline: none;
-  width: 100%;
-  border: none;
-}
-.sp-preview-container,
-.sp-wrapper,
-.sp-layout,
-.sp-stack,
-.sp-preview-iframe {
-  height: 100% !important;
 }

--- a/src/blocks/file-blocks/annotate-react/style.css
+++ b/src/blocks/file-blocks/annotate-react/style.css
@@ -1,10 +1,4 @@
-.sp-preview-iframe {
-  outline: none;
-  width: 100%;
-  border: none;
-}
-
-.sandbox-wrapper .sp-loading:before {
+.sp-loading:before {
   content: "Loading...";
   position: absolute;
   top: 30%;
@@ -13,4 +7,10 @@
   opacity: 0.5;
   transform: translate(-50%, -50%);
   font-style: italic;
+}
+
+.sp-preview-iframe {
+  outline: none;
+  width: 100%;
+  border: none;
 }

--- a/src/blocks/file-blocks/live-markdown/style.css
+++ b/src/blocks/file-blocks/live-markdown/style.css
@@ -1,4 +1,10 @@
-.sp-loading:before {
+.sp-preview-iframe {
+  outline: none;
+  width: 100%;
+  border: none;
+}
+
+.sandbox-wrapper .sp-loading:before {
   content: "Loading...";
   position: absolute;
   top: 30%;
@@ -7,16 +13,4 @@
   opacity: 0.5;
   transform: translate(-50%, -50%);
   font-style: italic;
-}
-.sp-preview-iframe {
-  outline: none;
-  width: 100%;
-  border: none;
-}
-.sp-preview-container,
-.sp-wrapper,
-.sp-layout,
-.sp-stack,
-.sp-preview-iframe {
-  height: 100% !important;
 }

--- a/src/blocks/file-blocks/live-markdown/style.css
+++ b/src/blocks/file-blocks/live-markdown/style.css
@@ -1,10 +1,4 @@
-.sp-preview-iframe {
-  outline: none;
-  width: 100%;
-  border: none;
-}
-
-.sandbox-wrapper .sp-loading:before {
+.sp-loading:before {
   content: "Loading...";
   position: absolute;
   top: 30%;
@@ -13,4 +7,10 @@
   opacity: 0.5;
   transform: translate(-50%, -50%);
   font-style: italic;
+}
+
+.sp-preview-iframe {
+  outline: none;
+  width: 100%;
+  border: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,12 @@
-/* ./src/index.css */
-
-html,
 body {
   margin: 0;
   padding: 0;
+}
+
+.sp-preview-iframe {
+  outline: none;
+  width: 100%;
+  border: none;
 }
 
 .sandbox-wrapper .sp-loading:before {
@@ -15,16 +18,4 @@ body {
   opacity: 0.5;
   transform: translate(-50%, -50%);
   font-style: italic;
-}
-.sandbox-wrapper .sp-preview-iframe {
-  outline: none;
-  width: 100%;
-  border: none;
-}
-.sandbox-wrapper .sp-preview-container,
-.sandbox-wrapper .sp-wrapper,
-.sandbox-wrapper .sp-layout,
-.sandbox-wrapper .sp-stack,
-.sandbox-wrapper .sp-preview-iframe {
-  height: 100% !important;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+/* ./src/index.css */
+
 html,
 body {
   margin: 0;
@@ -15,7 +17,7 @@ body {
   font-style: italic;
 }
 
-.sp-preview-iframe {
+.sandbox-wrapper .sp-preview-iframe {
   outline: none;
   width: 100%;
   border: none;

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,7 @@
+html,
 body {
   margin: 0;
   padding: 0;
-}
-
-.sp-preview-iframe {
-  outline: none;
-  width: 100%;
-  border: none;
 }
 
 .sandbox-wrapper .sp-loading:before {
@@ -18,4 +13,10 @@ body {
   opacity: 0.5;
   transform: translate(-50%, -50%);
   font-style: italic;
+}
+
+.sp-preview-iframe {
+  outline: none;
+  width: 100%;
+  border: none;
 }


### PR DESCRIPTION
CodeSandbox adjusts the iframe height to match the contents after React rendering, but our `height: 100% !important` on surrounding divs was defeating this for nested CodeSandboxes and causing the outer iframe to render at default height.

(This is @mattrothenberg's work, I just cleaned up the diff a little.)
