### PR TITLE
feat: store excal instance correctly

### DIFF
--- a/src/blocks/file-blocks/excalidraw/index.tsx
+++ b/src/blocks/file-blocks/excalidraw/index.tsx
@@ -1,27 +1,28 @@
 import { FileBlockProps } from "@githubnext/utils";
 import { useEffect, useState } from "react";
-import "./style.css"
+import "./style.css";
 
 if (typeof window !== "undefined") {
   // to load assets from self domain, instead of the CDN
   const urlObject = new URL(window.location.href);
-  const prototypeDomain = "https://next-devex-blocks.azurewebsites.net"
+  const prototypeDomain = "https://blocks.githubnext.com";
   const isPrototype = urlObject.origin === prototypeDomain;
   if (isPrototype) {
     // @ts-ignore
-    window.EXCALIDRAW_ASSET_PATH = "/excalidraw/"
+    window.EXCALIDRAW_ASSET_PATH = "/excalidraw/";
   }
 }
 export default function (props: FileBlockProps) {
   const { content, onRequestUpdateContent } = props;
-
   const [appState, setAppState] = useState(null);
   const [elements, setElements] = useState([]);
-  const [Excalidraw, setExcalidraw] = useState<any>(null);
+  const [excalModule, setExcalModule] = useState<any>(null);
 
   useEffect(() => {
-    import("@excalidraw/excalidraw").then(imp => setExcalidraw(imp.default))
-  }, [])
+    import("@excalidraw/excalidraw").then((imp) => {
+      setExcalModule(imp);
+    });
+  }, []);
 
   const handleChange = (elements: any, appState: any) => {
     setElements(elements);
@@ -29,24 +30,33 @@ export default function (props: FileBlockProps) {
   };
 
   const handleSave = async () => {
-    if (!Excalidraw.serializeAsJSON) return;
-    const serialized = Excalidraw.serializeAsJSON(elements, appState);
-    onRequestUpdateContent(serialized)
+    if (!excalModule) {
+      console.error("Excalidraw is not loaded.");
+      return;
+    }
+    const serialized = excalModule.serializeAsJSON(elements, appState);
+    onRequestUpdateContent(serialized);
   };
+
+  const ExcalidrawComponent = excalModule ? excalModule.default : null;
 
   return (
     <div className="position-relative height-full">
       <div className="width-full" key={content} style={{ height: "100vh" }}>
-        {Excalidraw && (
-          <Excalidraw
+        {ExcalidrawComponent && (
+          <ExcalidrawComponent
             initialData={JSON.parse(content)}
             onChange={handleChange}
           />
         )}
       </div>
-      <button className="btn btn-primary position-absolute right-2 top-2"
+      <button
+        className="btn btn-primary position-absolute right-4 top-4 z-10"
         style={{ zIndex: 1 }}
-        onClick={handleSave}>Save Changes</button>
+        onClick={handleSave}
+      >
+        Save Changes
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
Currently, the "Save Changes" button for the Excalidraw block is broken.

The issue stems from us incorrectly storing the Excalidraw instance in our `useEffect `hook. The module has a default export (which is the actual React component) as well as several other named exports, such as `serializeAsJSON`. Therefore we need to store the entire module in our state, rather than just the default export.

I've also gone ahead and updated our `prototypeDomain` to reflect the new Blocks URL.