### PR TITLE
Re-add processing block

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
       "extensions": [
         "js"
       ],
-      "example_path": "https://github.com/githubnext/blocks-tutorial/blob/ia/old-files/sketch-new2.js"
+      "example_path": "https://github.com/githubnext/blocks-tutorial/blob/main/processing-sketch.js"
     },
     {
       "type": "folder",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,17 @@
       "example_path": "https://github.com/githubnext/blocks-tutorial/blob/main/queries.json"
     },
     {
+      "type": "file",
+      "id": "processing-block",
+      "title": "Processing block",
+      "description": "Run your p5.js sketches",
+      "entry": "/src/blocks/file-blocks/processing.tsx",
+      "extensions": [
+        "js"
+      ],
+      "example_path": "https://github.com/githubnext/blocks-tutorial/blob/ia/old-files/sketch-new2.js"
+    },
+    {
       "type": "folder",
       "id": "minimap-block",
       "title": "Minimap",

--- a/src/blocks/file-blocks/processing.tsx
+++ b/src/blocks/file-blocks/processing.tsx
@@ -1,21 +1,64 @@
-import { createRef, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { FileBlockProps } from "@githubnext/utils";
-import p5 from "p5";
+import DOMPurify from "dompurify";
+
+type LoadingStatus = "ready" | "error" | "idle";
 
 export default function (props: FileBlockProps) {
   const { content } = props;
 
-  const p5Ref = createRef<HTMLDivElement>();
+  const sanitizedContent = useMemo(
+    () => DOMPurify.sanitize(content),
+    [content]
+  );
+
+  // load the p5.js library
+  // this is copied from the way we use to load tailwindcss
+  const src = "https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.js";
+
+  const [status, setStatus] = useState<LoadingStatus>("idle");
 
   useEffect(() => {
-    if (p5Ref.current) {
-      try {
-        new p5(eval(content), p5Ref.current);
-      } catch (e) {
-        // console.log(e);
+    const script = document.createElement("script");
+    script.src = src;
+    script.async = true;
+    script.setAttribute("data-status", "loading");
+    document.body.appendChild(script);
+    const setAttributeFromEvent = (event: any) => {
+      script.setAttribute(
+        "data-status",
+        event.type === "load" ? "ready" : "error"
+      );
+    };
+    script.addEventListener("load", setAttributeFromEvent);
+    script.addEventListener("error", setAttributeFromEvent);
+    const setStateFromEvent = (event: any) => {
+      setStatus(event.type === "load" ? "ready" : "error");
+    };
+    script.addEventListener("load", setStateFromEvent);
+    script.addEventListener("error", setStateFromEvent);
+    return () => {
+      if (script) {
+        script.removeEventListener("load", setStateFromEvent);
+        script.removeEventListener("error", setStateFromEvent);
       }
-    }
-  }, [p5Ref.current, content]);
+    };
+  }, []);
 
-  return <div ref={p5Ref}></div>;
+  // load the p5.js sketch from the content of a user's file
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.innerText = sanitizedContent;
+    document.body.appendChild(script);
+  }, []);
+
+  return (
+    <div
+      style={{
+        padding: "25px 20px",
+      }}
+    >
+      <div id="processing"></div>
+    </div>
+  );
 }

--- a/src/blocks/file-blocks/processing.tsx
+++ b/src/blocks/file-blocks/processing.tsx
@@ -1,64 +1,48 @@
-import { useEffect, useMemo, useState } from "react";
 import { FileBlockProps } from "@githubnext/utils";
-import DOMPurify from "dompurify";
-
-type LoadingStatus = "ready" | "error" | "idle";
+import { SandpackPreview, SandpackProvider } from "@codesandbox/sandpack-react";
 
 export default function (props: FileBlockProps) {
   const { content } = props;
 
-  const sanitizedContent = useMemo(
-    () => DOMPurify.sanitize(content),
-    [content]
-  );
-
-  // load the p5.js library
-  // this is copied from the way we use to load tailwindcss
-  const src = "https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.js";
-
-  const [status, setStatus] = useState<LoadingStatus>("idle");
-
-  useEffect(() => {
-    const script = document.createElement("script");
-    script.src = src;
-    script.async = true;
-    script.setAttribute("data-status", "loading");
-    document.body.appendChild(script);
-    const setAttributeFromEvent = (event: any) => {
-      script.setAttribute(
-        "data-status",
-        event.type === "load" ? "ready" : "error"
-      );
-    };
-    script.addEventListener("load", setAttributeFromEvent);
-    script.addEventListener("error", setAttributeFromEvent);
-    const setStateFromEvent = (event: any) => {
-      setStatus(event.type === "load" ? "ready" : "error");
-    };
-    script.addEventListener("load", setStateFromEvent);
-    script.addEventListener("error", setStateFromEvent);
-    return () => {
-      if (script) {
-        script.removeEventListener("load", setStateFromEvent);
-        script.removeEventListener("error", setStateFromEvent);
-      }
-    };
-  }, []);
-
-  // load the p5.js sketch from the content of a user's file
-  useEffect(() => {
-    const script = document.createElement("script");
-    script.innerText = sanitizedContent;
-    document.body.appendChild(script);
-  }, []);
-
   return (
     <div
       style={{
-        padding: "25px 20px",
+        width: "100%",
+        height: "100%",
       }}
     >
-      <div id="processing"></div>
+      <SandpackProvider
+        externalResources={[ 'https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.js' ]}
+        customSetup={{
+            files: {
+                "/src/index.js": {
+                  code: content,
+                },
+                "/index.html": {
+                  code: `<!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <main></main>
+    <script src="src/index.js"></script>
+  </body>
+  </html>`
+                }
+              },
+          dependencies: {},
+          entry: "/src/index.js",
+          main: "/src/index.js",
+          environment: "static",
+        }}
+        autorun
+      >
+        <SandpackPreview
+          showOpenInCodeSandbox={false}
+          showRefreshButton={false}
+        />
+      </SandpackProvider>
     </div>
   );
 }


### PR DESCRIPTION
We were blocked by security from using the original processing block because it was using `eval` to execute the javascript sketch code. 

In this version we embed a `SandboxProvider` just like we did for the annotate react block. 