### PR TITLE
Fix: height of processing block

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
       "id": "processing-block",
       "title": "Processing block",
       "description": "Run your p5.js sketches",
-      "entry": "/src/blocks/file-blocks/processing.tsx",
+      "entry": "/src/blocks/file-blocks/processing/processing.tsx",
       "extensions": [
         "js"
       ],

--- a/src/blocks/file-blocks/processing/processing.tsx
+++ b/src/blocks/file-blocks/processing/processing.tsx
@@ -1,5 +1,7 @@
 import { FileBlockProps } from "@githubnext/utils";
 import { SandpackPreview, SandpackProvider } from "@codesandbox/sandpack-react";
+// these styles are so that the codesandbox preview shows up with full height in Blocks app
+import "./style.css";
 
 export default function (props: FileBlockProps) {
   const { content } = props;

--- a/src/blocks/file-blocks/processing/style.css
+++ b/src/blocks/file-blocks/processing/style.css
@@ -1,0 +1,9 @@
+.sp-preview-iframe {
+  outline: none;
+  width: 100%;
+  border: none;
+}
+
+.sp-stack {
+  height: 100%;
+}


### PR DESCRIPTION
The processing block works perfectly in the local/prod sandbox, but the height is not full in the Blocks app. This PR fixes that. 

Have to add extra styles to make the codesandbox preview appear correctly in the Blocks prototype. Specifically:

```
.sp-stack {
  height: 100%;
}
```
