### PR TITLE
add `"sandbox": false` for trusted blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
       "id": "code-block",
       "title": "Code block",
       "description": "A basic code block",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/code/index.tsx",
       "extensions": [
         "*"
@@ -34,6 +35,7 @@
       "id": "excalidraw-block",
       "title": "Drawing block",
       "description": "A whiteboard tool",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/excalidraw/index.tsx",
       "extensions": [
         "excalidraw"
@@ -45,6 +47,7 @@
       "id": "html-block",
       "title": "HTML block",
       "description": "View HTML content",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/html.tsx",
       "extensions": [
         "html",
@@ -57,6 +60,7 @@
       "id": "css-block",
       "title": "Styleguide block",
       "description": "View selectors in a css file",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/css.tsx",
       "extensions": [
         "css"
@@ -68,6 +72,7 @@
       "id": "image-block",
       "title": "Image block",
       "description": "View images",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/image.tsx",
       "extensions": [
         "png",
@@ -83,6 +88,7 @@
       "id": "json-block",
       "title": "Object explorer",
       "description": "An interactive view of JSON objects",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/json.tsx",
       "extensions": [
         "json",
@@ -98,6 +104,7 @@
       "id": "3d-model-block",
       "title": "3D block",
       "description": "A block for 3d files",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/3d-files.tsx",
       "extensions": [
         "gltf",
@@ -110,6 +117,7 @@
       "id": "flat-block",
       "title": "Flat data block",
       "description": "A block for flat data files",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/flat.tsx",
       "extensions": [
         "csv"
@@ -121,6 +129,7 @@
       "id": "simple-poll-block",
       "title": "Poll block",
       "description": "View simple polls beautifully",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/poll.tsx",
       "extensions": [
         "json"
@@ -132,6 +141,7 @@
       "id": "chart-block",
       "title": "Chart block",
       "description": "An interactive chart block",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/charts/index.tsx",
       "extensions": [
         "csv"
@@ -167,6 +177,7 @@
       "id": "sentence-encoder-block",
       "title": "Sentence encoder block",
       "description": "Experiment with your sentence-encoder",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/sentence-encoder.tsx",
       "extensions": [
         "json"
@@ -189,6 +200,7 @@
       "id": "minimap-block",
       "title": "Minimap",
       "description": "A visualization of your folders and files",
+      "sandbox": false,
       "entry": "/src/blocks/folder-blocks/minimap/index.tsx",
       "example_path": "https://github.com/githubnext/blocks-tutorial"
     },
@@ -197,6 +209,7 @@
       "id": "dashboard-block",
       "title": "Dashboard",
       "description": "A dashboard of Blocks",
+      "sandbox": false,
       "entry": "/src/blocks/folder-blocks/dashboard/index.tsx",
       "example_path": "https://github.com/githubnext/blocks-tutorial"
     },
@@ -205,6 +218,7 @@
       "id": "code-tour-block",
       "title": "Code Tour",
       "description": "Create documented tours of your code",
+      "sandbox": false,
       "entry": "/src/blocks/folder-blocks/code-tour/index.tsx",
       "example_path": "https://github.com/githubnext/blocks-tutorial"
     }


### PR DESCRIPTION
This flag isn't consumed anywhere yet. Next steps are to make sure the flag is propagated through `blocks-marketplace` into `blocks`, sandbox in `blocks` according to the flag, then finally remove the self-sandboxing for the Markdown, Processing, and React feedback blocks. (This flag will take effect only for blocks in `githubnext/blocks-examples`; custom blocks will always be sandboxed just as now.)