### PR TITLE
set `sandbox: false` for self-sandboxed blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
       "id": "markdown-block",
       "title": "Markdown",
       "description": "View markdown files. You can also view live repo into, using Issues, Releases, and Commits custom components, as well as live code examples with CodeSandbox.",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/live-markdown/index.tsx",
       "extensions": [
         "md",
@@ -169,6 +170,7 @@
       "id": "react-feedback-block",
       "title": "React component feedback",
       "description": "Give feedback on a React component",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/annotate-react/index.tsx",
       "extensions": [
         "jsx",
@@ -193,6 +195,7 @@
       "id": "processing-block",
       "title": "Processing block",
       "description": "Run your p5.js sketches",
+      "sandbox": false,
       "entry": "/src/blocks/file-blocks/processing.tsx",
       "extensions": [
         "js"


### PR DESCRIPTION
removing the self-sandboxing of the Markdown, Processing, and React feedback blocks is not as straightforward as I had imagined 😬; temporarily marking them `sandbox: false` so they aren't double-sandboxed in `blocks`.