### PR TITLE
sandbox MDX block

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
     "@excalidraw/excalidraw": "^0.10.0",
     "@fullstackio/cq": "^6.0.9",
     "@fullstackio/remark-cq": "^6.1.2",
-    "@githubnext/utils": "^0.18.0",
+    "@githubnext/utils": "^0.19.3",
     "@githubocto/flat-ui": "^0.13.4",
     "@loadable/component": "^5.15.0",
     "@mdx-js/runtime": "2.0.0-next.9",

--- a/package.json
+++ b/package.json
@@ -156,8 +156,8 @@
       "type": "file",
       "id": "markdown-block",
       "title": "Markdown",
-      "description": "View markdown files. You can also view live repo into, using Issues, Releases, and Commits custom components, as well as live code examples with CodeSandbox.",
-      "sandbox": false,
+      "description": "View markdown files. You can also view live repo info, using Issues, Releases, and Commits custom components, as well as live code examples with CodeSandbox.",
+      "sandbox": true,
       "entry": "/src/blocks/file-blocks/live-markdown/index.tsx",
       "extensions": [
         "md",

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,10 +762,10 @@
     unist-util-visit "^1.0.0"
     uuid "^3.3.2"
 
-"@githubnext/utils@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.18.0.tgz#43e5c1909b6cabfe07c85b9c81525ebdbe04d035"
-  integrity sha512-Xsi7zUDt2vGgrHDvzDLpQWGXdyof65iV7PBWffu/cX/IJKXRG4KJ5zUt7lD7iAXYv4VOgnbmtI81B/ayt2vByQ==
+"@githubnext/utils@^0.19.3":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.19.3.tgz#31c535c70454c2a3363de8cea1f8bf0a30a3d556"
+  integrity sha512-WetjTPpR6nZMUwUNw30RuhOzAdeKCKgPy7Oh5jxRjr/kIKSGfJU7NY3knqqvPk3jD/JjavW0n6AoGWSOL7cvkA==
   dependencies:
     "@types/lodash.uniqueid" "^4.0.6"
     lodash.uniqueid "^4.0.1"


### PR DESCRIPTION
We're seeing errors here:
https://blocks.githubnext.com/githubnext/blocks-tutorial?path=README.md

I think because we're using `@mdx-js/runtime`