### PR TITLE
fix duplicate CodeMirror in code block

### DIFF
--- a/src/blocks/file-blocks/code/index.tsx
+++ b/src/blocks/file-blocks/code/index.tsx
@@ -97,7 +97,7 @@ export default function (props: FileBlockProps) {
         });
       });
     }
-  }, [editorRef.current]);
+  }, []);
 
   return (
     <div className="position-relative height-full">


### PR DESCRIPTION
When the code block is re-rendered, this `useEffect` runs a second time, creating a second CodeMirror instance. This is because of the dependency on `editorRef.current`—the first time through it's `null` when we call `useEffect`, but by the time the effect function runs it's set to the `div`, so we add a CodeMirror instance; the second time through it's set to the `div` when we call `useEffect`, so we run the effect function again. Fix is to drop the dependency and run the effect only once.
