### PR TITLE
remove save buttons + content update toasts

### DIFF
--- a/src/blocks/file-blocks/excalidraw/index.tsx
+++ b/src/blocks/file-blocks/excalidraw/index.tsx
@@ -13,9 +13,7 @@ if (typeof window !== "undefined") {
   }
 }
 export default function (props: FileBlockProps) {
-  const { content, onRequestUpdateContent } = props;
-  const [appState, setAppState] = useState(null);
-  const [elements, setElements] = useState([]);
+  const { context, content, onRequestUpdateContent } = props;
   const [excalModule, setExcalModule] = useState<any>(null);
 
   useEffect(() => {
@@ -25,11 +23,6 @@ export default function (props: FileBlockProps) {
   }, []);
 
   const handleChange = (elements: any, appState: any) => {
-    setElements(elements);
-    setAppState(appState);
-  };
-
-  const handleSave = async () => {
     if (!excalModule) {
       console.error("Excalidraw is not loaded.");
       return;
@@ -41,22 +34,13 @@ export default function (props: FileBlockProps) {
   const ExcalidrawComponent = excalModule ? excalModule.default : null;
 
   return (
-    <div className="position-relative height-full">
-      <div className="width-full" key={content} style={{ height: "100vh" }}>
-        {ExcalidrawComponent && (
-          <ExcalidrawComponent
-            initialData={JSON.parse(content)}
-            onChange={handleChange}
-          />
-        )}
-      </div>
-      <button
-        className="btn btn-primary position-absolute right-4 top-4 z-10"
-        style={{ zIndex: 1 }}
-        onClick={handleSave}
-      >
-        Save Changes
-      </button>
+    <div className="width-full" key={context.path} style={{ height: "100vh" }}>
+      {ExcalidrawComponent && (
+        <ExcalidrawComponent
+          initialData={JSON.parse(content)}
+          onChange={handleChange}
+        />
+      )}
     </div>
   );
 }

--- a/src/blocks/file-blocks/flat.tsx
+++ b/src/blocks/file-blocks/flat.tsx
@@ -6,9 +6,6 @@ import { useMemo, useState } from "react";
 export default function (props: FileBlockProps) {
   const { content, onRequestUpdateContent } = props;
 
-  const [modifiedData, setModifiedData] = useState<any[]>([]);
-  const [isDirty, setIsDirty] = useState(false);
-
   const data = useMemo(() => {
     try {
       const rows = csvParseRows(content);
@@ -19,8 +16,6 @@ export default function (props: FileBlockProps) {
           return acc;
         }, {});
       });
-      setModifiedData(csvData);
-      setIsDirty(false);
       return csvData;
     } catch (e) {
       return [];
@@ -28,34 +23,16 @@ export default function (props: FileBlockProps) {
   }, [content]);
 
   return (
-    <div className="height-full d-flex flex-column">
-      <div className="flex-1" style={{ zIndex: 1 }}>
-        <Grid
-          data={modifiedData}
-          diffData={data}
-          canDownload={false}
-          isEditable
-          onEdit={(data: any) => {
-            setModifiedData(data);
-            setIsDirty(true);
-          }}
-        />
-      </div>
-      {isDirty && (
-        <button
-          className="position-absolute btn btn-primary inline-block"
-          style={{
-            bottom: "12px",
-            right: "175px",
-            zIndex: 10,
-          }}
-          onClick={() => {
-            onRequestUpdateContent(csvFormat(modifiedData));
-          }}
-        >
-          Save changes
-        </button>
-      )}
+    <div className="height-full d-flex flex-column flex-1">
+      <Grid
+        data={data}
+        diffData={data}
+        canDownload={false}
+        isEditable
+        onEdit={(data: any) => {
+          onRequestUpdateContent(csvFormat(data));
+        }}
+      />
     </div>
   );
 }

--- a/src/blocks/file-blocks/geojson.tsx
+++ b/src/blocks/file-blocks/geojson.tsx
@@ -19,8 +19,6 @@ export default function (props: FileBlockProps) {
   const [hoveredFeatureId, setHoveredFeatureId] =
     useState<Feature<Geometry> | null>(null);
   const [isHoveredFeatureLocked, setIsHoveredFeatureLocked] = useState(false);
-  const [isDirty, setIsDirty] = useState(false);
-  const [modifiedContent, setModifiedContent] = useState(content);
   const [lastExtent, setLastExtent] = useState<
     [number, number, number, number] | null
   >([0, 0, 0, 0]);
@@ -32,12 +30,11 @@ export default function (props: FileBlockProps) {
     setTimeout(() => {
       setIsMounted(true);
     });
-    setModifiedContent(content);
   }, [content]);
 
   const geojson = useMemo(() => {
     try {
-      let geojsonObject = JSON.parse(modifiedContent);
+      let geojsonObject = JSON.parse(content);
       if (!geojsonObject.features) {
         geojsonObject = {
           type: "FeatureCollection",
@@ -55,7 +52,7 @@ export default function (props: FileBlockProps) {
     } catch (e) {
       return {};
     }
-  }, [modifiedContent]);
+  }, [content]);
 
   const features = useMemo(() => parseGeoJSON(geojson), [geojson]);
 
@@ -200,7 +197,7 @@ export default function (props: FileBlockProps) {
                               );
                               if (index === -1) return;
 
-                              let newGeojson = JSON.parse(modifiedContent);
+                              let newGeojson = JSON.parse(content);
                               const isCollection =
                                 newGeojson.type === "FeatureCollection";
                               if (isCollection) {
@@ -226,8 +223,9 @@ export default function (props: FileBlockProps) {
                                   [key]: value,
                                 };
                               }
-                              setModifiedContent(JSON.stringify(newGeojson));
-                              setIsDirty(true);
+                              onRequestUpdateContent(
+                                JSON.stringify(newGeojson)
+                              );
                             }}
                           />
                         ) : (
@@ -242,18 +240,6 @@ export default function (props: FileBlockProps) {
               )}
           </div>
         </div>
-      )}
-
-      {isDirty && (
-        <button
-          className="position-absolute d-block top-2 right-2 btn btn-primary"
-          onClick={() => {
-            const contentString = modifiedContent;
-            onRequestUpdateContent(contentString);
-          }}
-        >
-          Save changes
-        </button>
       )}
     </div>
   );

--- a/src/blocks/file-blocks/json.tsx
+++ b/src/blocks/file-blocks/json.tsx
@@ -1,31 +1,20 @@
 import { FileBlockProps } from "@githubnext/utils";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import ReactJson from "react-json-view";
 import jsYaml from "js-yaml";
 
 export default function (props: FileBlockProps) {
   const { content, context, onRequestUpdateContent } = props;
 
-  const [modifiedContent, setModifiedContent] = useState(content);
-
-  useEffect(() => {
-    setModifiedContent(content);
-  }, [content]);
-
-  const normalizeContent = (str: string) => {
-    try {
-      return JSON.stringify(JSON.parse(str));
-    } catch (e) {
-      return str;
-    }
-  };
-
-  const isDirty = useMemo(() => {
-    return normalizeContent(modifiedContent) !== normalizeContent(content);
-  }, [modifiedContent, content]);
-
   const extension = context.path.split(".").pop() || "";
   const isYaml = ["yaml", "yml"].includes(extension);
+
+  const setModifiedContent = (data: string) => {
+    const contentString = isYaml
+      ? jsYaml.dump(data)
+      : JSON.stringify(data, null, 2);
+    onRequestUpdateContent(contentString);
+  };
 
   const data = useMemo(() => {
     try {
@@ -85,30 +74,6 @@ export default function (props: FileBlockProps) {
               setModifiedContent(e.updated_src);
             }}
           />
-          {isDirty && (
-            <button
-              style={{
-                position: "absolute",
-                top: "2em",
-                right: "2em",
-                padding: "0.6em 1.2em",
-                fontSize: "1em",
-                backgroundColor: "#6366f1",
-                color: "#fff",
-                border: "none",
-                borderRadius: "2em",
-                cursor: "pointer",
-              }}
-              onClick={() => {
-                const contentString = isYaml
-                  ? jsYaml.dump(data)
-                  : JSON.stringify(data, null, 2);
-                onRequestUpdateContent(contentString);
-              }}
-            >
-              Save changes
-            </button>
-          )}
         </>
       ) : (
         <div

--- a/src/components/callback-notifications.tsx
+++ b/src/components/callback-notifications.tsx
@@ -29,11 +29,6 @@ export const CallbackNotifications = ({}) => {
           info: <>New metadata:</>,
           details: JSON.stringify(event.data.metadata, null, 2),
         },
-        "update-file": {
-          title: "Update file contents",
-          info: <>New file contents:</>,
-          details: JSON.stringify(event.data.content, null, 2),
-        },
         "navigate-to-path": {
           title: "Navigate to path",
           info: <>Requested to navigate to page:</>,

--- a/src/components/file-block.tsx
+++ b/src/components/file-block.tsx
@@ -55,7 +55,7 @@ export function FileBlock(props: Omit<AppInnerProps, "onReset" | "blockType">) {
         }}
       >
         <ProductionBlock
-          contents={data.content}
+          content={data.content}
           context={{
             ...data.context,
             file: name,
@@ -73,7 +73,7 @@ export function FileBlock(props: Omit<AppInnerProps, "onReset" | "blockType">) {
         }}
       >
         <LocalBlock
-          contents={data.content}
+          content={data.content}
           context={{
             ...data.context,
             file: name,

--- a/src/components/local-block.tsx
+++ b/src/components/local-block.tsx
@@ -27,6 +27,7 @@ interface LocalBlockProps {
 }
 export const LocalBlock = (props: LocalBlockProps) => {
   const { block, contents, tree, metadata = {}, context } = props;
+  const [content, setContent] = useState<string>(contents || "");
 
   const [Block, setBlock] = useState<React.ComponentType<any> | null>(null);
 
@@ -56,18 +57,6 @@ export const LocalBlock = (props: LocalBlockProps) => {
       {
         type: "navigate-to-path",
         path,
-      },
-      "*"
-    );
-  }, []);
-  const onRequestUpdateContent = useCallback((content) => {
-    console.log(`Triggered a request to update the file contents`);
-    console.log("From:", contents);
-    console.log("To:", content);
-    window.postMessage(
-      {
-        type: "update-file",
-        content,
       },
       "*"
     );
@@ -103,12 +92,12 @@ export const LocalBlock = (props: LocalBlockProps) => {
   return (
     <Block
       context={context}
-      content={contents}
+      content={content}
       tree={tree}
       metadata={metadata}
       onUpdateMetadata={onUpdateMetadata}
       onNavigateToPath={onNavigateToPath}
-      onRequestUpdateContent={onRequestUpdateContent}
+      onRequestUpdateContent={setContent}
       onRequestGitHubData={onRequestGitHubData}
     />
   );

--- a/src/components/local-block.tsx
+++ b/src/components/local-block.tsx
@@ -20,14 +20,20 @@ interface Block {
 }
 interface LocalBlockProps {
   block: Block;
-  contents?: string;
+  content?: string;
   tree?: RepoFiles;
   metadata?: any;
   context: FileContext | FolderContext;
 }
 export const LocalBlock = (props: LocalBlockProps) => {
-  const { block, contents, tree, metadata = {}, context } = props;
-  const [content, setContent] = useState<string>(contents || "");
+  const {
+    block,
+    content: originalContent,
+    tree,
+    metadata = {},
+    context,
+  } = props;
+  const [content, setContent] = useState<string>(originalContent || "");
 
   const [Block, setBlock] = useState<React.ComponentType<any> | null>(null);
 

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -31,6 +31,7 @@ interface BundleCode {
 }
 export const ProductionBlock = (props: ProductionBlockProps) => {
   const { block, contents, tree, metadata = {}, context } = props;
+  const [content, setContent] = useState<string>(contents || "");
 
   const [bundleCode, setBundleCode] = useState<BundleCode[]>([]);
   const id = useRef(uniqueId("sandboxed-block-"));
@@ -92,6 +93,8 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
                 origin
               );
             });
+        } else if (data.type === "update-file") {
+          setContent(data.content);
         }
       }
     };
@@ -108,7 +111,7 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
     bundleCode,
     context,
     id: id.current,
-    contents,
+    contents: content,
     tree,
     metadata,
   });

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -20,7 +20,7 @@ type Block = {
 };
 interface ProductionBlockProps {
   block: Block;
-  contents?: string;
+  content?: string;
   tree?: RepoFiles;
   metadata?: any;
   context: FileContext | FolderContext;
@@ -30,8 +30,14 @@ interface BundleCode {
   content: string;
 }
 export const ProductionBlock = (props: ProductionBlockProps) => {
-  const { block, contents, tree, metadata = {}, context } = props;
-  const [content, setContent] = useState<string>(contents || "");
+  const {
+    block,
+    content: originalContent,
+    tree,
+    metadata = {},
+    context,
+  } = props;
+  const [content, setContent] = useState<string>(originalContent || "");
 
   const [bundleCode, setBundleCode] = useState<BundleCode[]>([]);
   const id = useRef(uniqueId("sandboxed-block-"));


### PR DESCRIPTION
With https://github.com/githubnext/blocks/pull/103 blocks no longer need their own save buttons; remove them. Also remove the toasts that appear when you call `onRequestUpdateContent`.

Instead, the framework updates the `content` prop when `onRequestUpdateContent` is called, and blocks must handle being controlled by the `content` prop.