### PR TITLE
code block: track `onRequestUpdateContent` so the `updateListener` callback gets the latest one.

### DIFF
--- a/src/blocks/file-blocks/code/index.tsx
+++ b/src/blocks/file-blocks/code/index.tsx
@@ -84,10 +84,12 @@ export default function (props: FileBlockProps) {
 
   const editorRef = React.useRef<HTMLDivElement>(null);
 
-  const viewRef = React.useMemo<{ current: EditorView | null }>(
-    () => ({ current: null }),
-    []
-  );
+  // track `onRequestUpdateContent` so the `updateListener` callback gets the latest one.
+  const onRequestUpdateContentRef =
+    React.useRef<typeof onRequestUpdateContent>();
+  onRequestUpdateContentRef.current = onRequestUpdateContent;
+
+  const viewRef = React.useRef<EditorView>();
 
   if (viewRef.current) {
     const view = viewRef.current;
@@ -108,7 +110,8 @@ export default function (props: FileBlockProps) {
         extensions,
         EditorView.updateListener.of((v) => {
           if (!v.docChanged) return;
-          onRequestUpdateContent(v.state.doc.sliceString(0));
+          if (!onRequestUpdateContentRef.current) return;
+          onRequestUpdateContentRef.current(v.state.doc.sliceString(0));
         }),
       ],
     });


### PR DESCRIPTION
In `blocks` / `RepoDetail` / `BlockPaneBlock` we pass a different `onRequestUpdateContent` prop depending on the current state of updated content. Here we call `onRequestUpdateContent` from a callback in the CodeMirror state, which wasn't updated when the prop changes. The fix is to track the prop in a ref and use the ref from the callback. (We can't make it `onRequestUpdateContent` a dep of `useRef` because that would cause the whole editor to be recreated when it changes.)

Alternatively we could hide this complexity in `blocks`, so individual blocks don't need to worry about it. We'd do the same thing — the single `onRequestUpdateContent` function would close over refs to its deps, and `BlockPaneBlock` would update those refs with current props.