### PR TITLE
feat: remove global TW dependency, introduce @primer/react

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -16,7 +16,7 @@ async function main() {
       format: "iife",
       globalName: "BlockBundle",
       minify: true,
-      external: ["fs", "path", "assert", "react", "react-dom"],
+      external: ["fs", "path", "assert", "react", "react-dom", "@primer/react"],
     });
   });
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GitHub Blocks: Custom Blocks</title>
-    <script src="https://cdn.tailwindcss.com"></script>
     <link
       href="https://unpkg.com/@primer/css@^19.0.0/dist/primer.css"
       rel="stylesheet"

--- a/index.html
+++ b/index.html
@@ -5,10 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GitHub Blocks: Custom Blocks</title>
-    <link
-      href="https://unpkg.com/@primer/css@^19.0.0/dist/primer.css"
-      rel="stylesheet"
-    />
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
     "@excalidraw/excalidraw": "^0.10.0",
     "@fullstackio/cq": "^6.0.9",
     "@fullstackio/remark-cq": "^6.1.2",
-    "@githubnext/utils": "^0.21.0",
+    "@githubnext/utils": "^0.22.0",
     "@githubocto/flat-ui": "^0.13.4",
     "@loadable/component": "^5.15.0",
     "@mdx-js/runtime": "2.0.0-next.9",

--- a/package.json
+++ b/package.json
@@ -457,6 +457,7 @@
     "rlayers": "^1.3.2",
     "styled-components": "^5.3.3",
     "three": "^0.134.0",
+    "twind": "^0.16.17",
     "unidiff": "^1.0.2"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -399,7 +399,7 @@
     "@codemirror/search": "^0.19.9",
     "@codemirror/state": "^0.19.9",
     "@codemirror/view": "^0.19.48",
-    "@codesandbox/sandpack-react": "^0.13.13",
+    "@codesandbox/sandpack-react": "^0.19.3",
     "@excalidraw/excalidraw": "^0.10.0",
     "@fullstackio/cq": "^6.0.9",
     "@fullstackio/remark-cq": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -409,7 +409,6 @@
     "@mdx-js/runtime": "2.0.0-next.9",
     "@octokit/rest": "^18.12.0",
     "@octokit/types": "^6.34.0",
-    "@primer/components": "^31.1.0",
     "@primer/octicons-react": "^16.0.0",
     "@primer/react": "^35.2.0",
     "@react-three/drei": "^7.20.5",

--- a/src/blocks/file-blocks/3d-files.tsx
+++ b/src/blocks/file-blocks/3d-files.tsx
@@ -1,4 +1,5 @@
 import { Suspense, useRef, useState, useEffect } from "react";
+import { tw } from "twind";
 import { PerspectiveCamera, useGLTF } from "@react-three/drei";
 import { Canvas, useLoader, useStore } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";

--- a/src/blocks/file-blocks/annotate-react/index.tsx
+++ b/src/blocks/file-blocks/annotate-react/index.tsx
@@ -21,7 +21,7 @@ import {
   TextInput,
   ActionList,
 } from "@primer/react";
-import { PlusIcon } from "@primer/octicons-react";
+import { CheckIcon, PlusIcon, TrashIcon } from "@primer/octicons-react";
 
 export default function ({
   content,
@@ -268,17 +268,7 @@ const AnnotationSetList = ({
                 }}
               >
                 <ActionList.LeadingVisual>
-                  <svg
-                    viewBox="0 0 16 16"
-                    width="16"
-                    height="16"
-                    className={tw(`ActionList-item-singleSelectCheckmark`)}
-                  >
-                    <path
-                      fill-rule="evenodd"
-                      d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                    ></path>
-                  </svg>
+                  <CheckIcon />
                 </ActionList.LeadingVisual>
 
                 <span
@@ -303,17 +293,7 @@ const AnnotationSetList = ({
                     onUpdateMetadata({ saved: newSaved });
                   }}
                 >
-                  <svg
-                    className={tw(`h-5 w-5`)}
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
+                  <TrashIcon />
                 </button>
               </ActionList.Item>
             );

--- a/src/blocks/file-blocks/annotate-react/index.tsx
+++ b/src/blocks/file-blocks/annotate-react/index.tsx
@@ -70,6 +70,7 @@ ReactDOM.render(
         saved={metadata.saved || []}
         onUpdateMetadata={onUpdateMetadata}
         annotations={annotations}
+        componentName={componentName || ""}
         // @ts-ignore
         setAnnotations={setAnnotations}
         componentDefinition={componentDefinition}
@@ -136,22 +137,24 @@ const Annotator = ({
 
   return (
     <div className={tw(`flex w-full h-full`)}>
-      <div className={tw(`flex-1 w-full h-full p-5 pt-0 z-10`)}>
-        <RadioGroup name="annotationType">
-          <RadioGroup.Label>Annotation Type</RadioGroup.Label>
-          {annotationTypes.map(({ id, name }) => (
-            <FormControl key={id}>
-              <Radio
-                checked={annotationType === id}
-                onChange={() => setAnnotationType(id)}
-                value={id}
-              />
-              <FormControl.Label>{name}</FormControl.Label>
-            </FormControl>
-          ))}
-        </RadioGroup>
+      <div className={tw(`flex-1 w-full h-full p-5 z-10`)}>
+        <div className={tw(`p-3`)}>
+          <RadioGroup name="annotationType">
+            <RadioGroup.Label>Annotation Type</RadioGroup.Label>
+            {annotationTypes.map(({ id, name }) => (
+              <FormControl key={id}>
+                <Radio
+                  checked={annotationType === id}
+                  onChange={() => setAnnotationType(id)}
+                  value={id}
+                />
+                <FormControl.Label>{name}</FormControl.Label>
+              </FormControl>
+            ))}
+          </RadioGroup>
+        </div>
 
-        <div className={tw(`h-full`)}>
+        <div className={tw(`h-full w-full`)}>
           <Annotation
             annotations={annotations}
             type={annotationType}
@@ -174,19 +177,21 @@ const AnnotationSetList = ({
   onUpdateMetadata,
   annotations,
   setAnnotations,
+  componentName,
   componentDefinition,
   setComponentDefinition,
 }: {
   saved: AnnotationSet[];
   onUpdateMetadata: (metadata: any) => void;
   annotations: AnnotationType[];
+  componentName: string;
   setAnnotations: (annotations: AnnotationType[]) => void;
   componentDefinition: string;
   setComponentDefinition: (componentDefinition: string) => void;
 }) => {
   const [title, setTitle] = useState("");
 
-  const canSubmitForm = annotations.length && title.length;
+  const canSubmitForm = !!annotations.length && title.length;
   const selectedAnnotationSetString = annotationSetToString({
     title,
     componentDefinition,
@@ -254,7 +259,7 @@ const AnnotationSetList = ({
       </form>
       <div className={tw(`flex-1 px-5 py-3 flex flex-col h-full w-full mt-3`)}>
         <div className={tw(`font-semibold`)}>Saved annotation sets</div>
-        <ActionList>
+        <ActionList selectionVariant="single">
           {saved.map((annotationSet, index) => {
             const isSelected = selectedAnnotationSetIndex === index;
             return (
@@ -267,10 +272,6 @@ const AnnotationSetList = ({
                   setTitle(annotationSet.title);
                 }}
               >
-                <ActionList.LeadingVisual>
-                  <CheckIcon />
-                </ActionList.LeadingVisual>
-
                 <span
                   className={tw(
                     `flex-1 flex flex-col justify-start items-start`
@@ -303,7 +304,7 @@ const AnnotationSetList = ({
           className={tw(`w-full`)}
           onClick={() => {
             setAnnotations([]);
-            setComponentDefinition("");
+            setComponentDefinition(`<${componentName}>\n</${componentName}>`);
             setTitle("");
           }}
           leadingIcon={PlusIcon}

--- a/src/blocks/file-blocks/annotate-react/index.tsx
+++ b/src/blocks/file-blocks/annotate-react/index.tsx
@@ -1,7 +1,7 @@
 // @ts-ignore
 import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
-import { Fragment, useState } from "react";
+import { useState } from "react";
 // @ts-ignore
 import Annotation from "react-image-annotation";
 import {
@@ -12,6 +12,16 @@ import {
 } from "react-image-annotation/lib/selectors";
 // @ts-ignore
 import { CodeSandbox } from "./CodeSandbox.tsx";
+import {
+  Button,
+  FormControl,
+  Radio,
+  RadioGroup,
+  Textarea,
+  TextInput,
+  ActionList,
+} from "@primer/react";
+import { PlusIcon } from "@primer/octicons-react";
 
 export default function ({
   content,
@@ -127,27 +137,20 @@ const Annotator = ({
   return (
     <div className={tw(`flex w-full h-full`)}>
       <div className={tw(`flex-1 w-full h-full p-5 pt-0 z-10`)}>
-        <div className={tw(`flex w-full items-center pb-1`)}>
-          <label htmlFor="name">Annotation type</label>
+        <RadioGroup name="annotationType">
+          <RadioGroup.Label>Annotation Type</RadioGroup.Label>
+          {annotationTypes.map(({ id, name }) => (
+            <FormControl key={id}>
+              <Radio
+                checked={annotationType === id}
+                onChange={() => setAnnotationType(id)}
+                value={id}
+              />
+              <FormControl.Label>{name}</FormControl.Label>
+            </FormControl>
+          ))}
+        </RadioGroup>
 
-          <div className={tw(`radio-group ml-2`)}>
-            {annotationTypes.map(({ id, name }) => (
-              <Fragment key={id}>
-                <input
-                  className={tw(`radio-input`)}
-                  id={id}
-                  type="radio"
-                  name="annotations"
-                  checked={annotationType === id}
-                  onChange={() => setAnnotationType(id)}
-                />
-                <label className={tw(`radio-label`)} htmlFor={id}>
-                  {name}
-                </label>
-              </Fragment>
-            ))}
-          </div>
-        </div>
         <div className={tw(`h-full`)}>
           <Annotation
             annotations={annotations}
@@ -213,133 +216,120 @@ const AnnotationSetList = ({
           onUpdateMetadata(newMetadata);
         }}
       >
-        <label className={tw(`mt-8 pb-4`)}>Annotation set title</label>
-        <input
-          type="text"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          className={tw(`form-control w-full mb-2`)}
-        />
-        <label className={tw(``)}>Component definition</label>
-        <p className={tw(`note`)}>You can specify the props and children</p>
-        <textarea
-          className={tw(`w-full mb-3 form-control`)}
-          value={componentDefinition}
-          onChange={(e) => {
-            const value = e.target.value;
-            if (!value) return;
-            setComponentDefinition(value);
-          }}
-        />
-        <button
-          className={`btn btn-primary w-full`}
+        <div className={tw(`mb-3`)}>
+          <FormControl>
+            <FormControl.Label>Annotation Set Title</FormControl.Label>
+            <TextInput
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </FormControl>
+        </div>
+        <div className={tw(`mb-3`)}>
+          <FormControl>
+            <FormControl.Label>Component Definition</FormControl.Label>
+            <FormControl.Caption>
+              You can specify the props and children
+            </FormControl.Caption>
+            <Textarea
+              rows={3}
+              value={componentDefinition}
+              onChange={(e) => {
+                const value = e.target.value;
+                if (!value) return;
+                setComponentDefinition(value);
+              }}
+            />
+          </FormControl>
+        </div>
+
+        <Button
+          className={tw(`w-full`)}
+          variant="primary"
           aria-disabled={!canSubmitForm ? "true" : undefined}
           type="submit"
         >
           Save new annotation set
-        </button>
+        </Button>
       </form>
       <div className={tw(`flex-1 px-5 py-3 flex flex-col h-full w-full mt-3`)}>
         <div className={tw(`font-semibold`)}>Saved annotation sets</div>
-        <ul
-          className={tw(`ActionList pl-0`)}
-          role="listbox"
-          aria-label="Select an option"
-        >
+        <ActionList>
           {saved.map((annotationSet, index) => {
             const isSelected = selectedAnnotationSetIndex === index;
             return (
-              <li
+              <ActionList.Item
+                selected={isSelected}
                 key={index}
-                className={tw(`ActionList-item`)}
-                role="option"
-                aria-selected={isSelected ? "true" : "false"}
+                onSelect={() => {
+                  setAnnotations(annotationSet.annotations);
+                  setComponentDefinition(annotationSet.componentDefinition);
+                  setTitle(annotationSet.title);
+                }}
               >
+                <ActionList.LeadingVisual>
+                  <svg
+                    viewBox="0 0 16 16"
+                    width="16"
+                    height="16"
+                    className={tw(`ActionList-item-singleSelectCheckmark`)}
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
+                    ></path>
+                  </svg>
+                </ActionList.LeadingVisual>
+
+                <span
+                  className={tw(
+                    `flex-1 flex flex-col justify-start items-start`
+                  )}
+                >
+                  {annotationSet.title}
+                  <span className={tw(`note`)}>
+                    {annotationSet.annotations.length} annotation
+                    {annotationSet.annotations.length > 1 ? "s" : ""}
+                  </span>
+                </span>
+
                 <button
-                  className={tw(`group w-full ActionList-content`)}
-                  onClick={() => {
-                    setAnnotations(annotationSet.annotations);
-                    setComponentDefinition(annotationSet.componentDefinition);
-                    setTitle(annotationSet.title);
+                  className={tw(
+                    `absolute top-1/2 right-2 h-10 w-10 transform -translate-y-1/2 cursor-pointer flex items-center justify-center transition-opacity opacity-0 group-hover:opacity-100 focus:opacity-100`
+                  )}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const newSaved = saved.filter((_, i) => i !== index);
+                    onUpdateMetadata({ saved: newSaved });
                   }}
                 >
-                  <span
-                    className={tw(
-                      `ActionList-item-action ActionList-item-action--leading`
-                    )}
+                  <svg
+                    className={tw(`h-5 w-5`)}
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
                   >
-                    <svg
-                      viewBox="0 0 16 16"
-                      width="16"
-                      height="16"
-                      className={tw(`ActionList-item-singleSelectCheckmark`)}
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                      ></path>
-                    </svg>
-                  </span>
-                  <span
-                    className={tw(
-                      `ActionList-item-label flex-1 flex flex-col justify-start items-start`
-                    )}
-                  >
-                    {annotationSet.title}
-                    <span className={tw(`note`)}>
-                      {annotationSet.annotations.length} annotation
-                      {annotationSet.annotations.length > 1 ? "s" : ""}
-                    </span>
-                  </span>
-
-                  <button
-                    className={tw(
-                      `absolute top-1/2 right-2 h-10 w-10 transform -translate-y-1/2 cursor-pointer flex items-center justify-center transition-opacity opacity-0 group-hover:opacity-100 focus:opacity-100`
-                    )}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      const newSaved = saved.filter((_, i) => i !== index);
-                      onUpdateMetadata({ saved: newSaved });
-                    }}
-                  >
-                    <svg
-                      className={tw(`h-5 w-5`)}
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </button>
+                    <path
+                      fillRule="evenodd"
+                      d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
                 </button>
-              </li>
+              </ActionList.Item>
             );
           })}
-        </ul>
-        <button
-          className={tw(`group relative w-full btn`)}
+        </ActionList>
+        <Button
+          className={tw(`w-full`)}
           onClick={() => {
             setAnnotations([]);
             setComponentDefinition("");
             setTitle("");
           }}
+          leadingIcon={PlusIcon}
         >
-          <svg
-            className={tw(`h-4 w-4 octicon mr-1`)}
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path
-              fillRule="evenodd"
-              d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
-              clipRule="evenodd"
-            />
-          </svg>
           Create a new annotation set
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/blocks/file-blocks/annotate-react/index.tsx
+++ b/src/blocks/file-blocks/annotate-react/index.tsx
@@ -1,4 +1,5 @@
 // @ts-ignore
+import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
 import { Fragment, useState } from "react";
 // @ts-ignore
@@ -43,8 +44,8 @@ ReactDOM.render(
 `;
 
   return (
-    <div className="relative w-full flex h-full">
-      <div className="flex flex-col flex-1 h-full max-w-[80em]">
+    <div className={tw(`relative w-full flex h-full`)}>
+      <div className={tw(`flex flex-col flex-1 h-full max-w-[80em]`)}>
         <Annotator
           annotations={annotations}
           // @ts-ignore
@@ -124,30 +125,30 @@ const Annotator = ({
   };
 
   return (
-    <div className="flex w-full h-full">
-      <div className="flex-1 w-full h-full p-5 pt-0 z-10">
-        <div className="flex w-full items-center pb-1">
+    <div className={tw(`flex w-full h-full`)}>
+      <div className={tw(`flex-1 w-full h-full p-5 pt-0 z-10`)}>
+        <div className={tw(`flex w-full items-center pb-1`)}>
           <label htmlFor="name">Annotation type</label>
 
-          <div className="radio-group ml-2">
+          <div className={tw(`radio-group ml-2`)}>
             {annotationTypes.map(({ id, name }) => (
               <Fragment key={id}>
                 <input
-                  className="radio-input"
+                  className={tw(`radio-input`)}
                   id={id}
                   type="radio"
                   name="annotations"
                   checked={annotationType === id}
                   onChange={() => setAnnotationType(id)}
                 />
-                <label className="radio-label" htmlFor={id}>
+                <label className={tw(`radio-label`)} htmlFor={id}>
                   {name}
                 </label>
               </Fragment>
             ))}
           </div>
         </div>
-        <div className="h-full">
+        <div className={tw(`h-full`)}>
           <Annotation
             annotations={annotations}
             type={annotationType}
@@ -155,7 +156,9 @@ const Annotator = ({
             onChange={setAnnotation}
             onSubmit={onAddAnnotation}
           >
-            <div className="relative w-full h-full z-[-1]">{children}</div>
+            <div className={tw(`relative w-full h-full z-[-1]`)}>
+              {children}
+            </div>
           </Annotation>
         </div>
       </div>
@@ -191,9 +194,9 @@ const AnnotationSetList = ({
   );
 
   return (
-    <div className="w-80 h-full flex flex-col divide-y divide-gray-200">
+    <div className={tw(`w-80 h-full flex flex-col divide-y divide-gray-200`)}>
       <form
-        className="px-5 pt-5 pb-2"
+        className={tw(`px-5 pt-5 pb-2`)}
         onSubmit={(e) => {
           e.preventDefault();
           if (!canSubmitForm) return;
@@ -210,17 +213,17 @@ const AnnotationSetList = ({
           onUpdateMetadata(newMetadata);
         }}
       >
-        <label className="mt-8 pb-4">Annotation set title</label>
+        <label className={tw(`mt-8 pb-4`)}>Annotation set title</label>
         <input
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          className="form-control w-full mb-2"
+          className={tw(`form-control w-full mb-2`)}
         />
-        <label className="">Component definition</label>
-        <p className="note">You can specify the props and children</p>
+        <label className={tw(``)}>Component definition</label>
+        <p className={tw(`note`)}>You can specify the props and children</p>
         <textarea
-          className="w-full mb-3 form-control"
+          className={tw(`w-full mb-3 form-control`)}
           value={componentDefinition}
           onChange={(e) => {
             const value = e.target.value;
@@ -236,10 +239,10 @@ const AnnotationSetList = ({
           Save new annotation set
         </button>
       </form>
-      <div className="flex-1 px-5 py-3 flex flex-col h-full w-full mt-3">
-        <div className="font-semibold">Saved annotation sets</div>
+      <div className={tw(`flex-1 px-5 py-3 flex flex-col h-full w-full mt-3`)}>
+        <div className={tw(`font-semibold`)}>Saved annotation sets</div>
         <ul
-          className="ActionList pl-0"
+          className={tw(`ActionList pl-0`)}
           role="listbox"
           aria-label="Select an option"
         >
@@ -248,24 +251,28 @@ const AnnotationSetList = ({
             return (
               <li
                 key={index}
-                className="ActionList-item"
+                className={tw(`ActionList-item`)}
                 role="option"
                 aria-selected={isSelected ? "true" : "false"}
               >
                 <button
-                  className="group w-full ActionList-content"
+                  className={tw(`group w-full ActionList-content`)}
                   onClick={() => {
                     setAnnotations(annotationSet.annotations);
                     setComponentDefinition(annotationSet.componentDefinition);
                     setTitle(annotationSet.title);
                   }}
                 >
-                  <span className="ActionList-item-action ActionList-item-action--leading">
+                  <span
+                    className={tw(
+                      `ActionList-item-action ActionList-item-action--leading`
+                    )}
+                  >
                     <svg
                       viewBox="0 0 16 16"
                       width="16"
                       height="16"
-                      className="ActionList-item-singleSelectCheckmark"
+                      className={tw(`ActionList-item-singleSelectCheckmark`)}
                     >
                       <path
                         fill-rule="evenodd"
@@ -273,16 +280,22 @@ const AnnotationSetList = ({
                       ></path>
                     </svg>
                   </span>
-                  <span className="ActionList-item-label flex-1 flex flex-col justify-start items-start">
+                  <span
+                    className={tw(
+                      `ActionList-item-label flex-1 flex flex-col justify-start items-start`
+                    )}
+                  >
                     {annotationSet.title}
-                    <span className="note">
+                    <span className={tw(`note`)}>
                       {annotationSet.annotations.length} annotation
                       {annotationSet.annotations.length > 1 ? "s" : ""}
                     </span>
                   </span>
 
                   <button
-                    className="absolute top-1/2 right-2 h-10 w-10 transform -translate-y-1/2 cursor-pointer flex items-center justify-center transition-opacity opacity-0 group-hover:opacity-100 focus:opacity-100"
+                    className={tw(
+                      `absolute top-1/2 right-2 h-10 w-10 transform -translate-y-1/2 cursor-pointer flex items-center justify-center transition-opacity opacity-0 group-hover:opacity-100 focus:opacity-100`
+                    )}
                     onClick={(e) => {
                       e.stopPropagation();
                       const newSaved = saved.filter((_, i) => i !== index);
@@ -290,7 +303,7 @@ const AnnotationSetList = ({
                     }}
                   >
                     <svg
-                      className="h-5 w-5"
+                      className={tw(`h-5 w-5`)}
                       viewBox="0 0 20 20"
                       fill="currentColor"
                     >
@@ -307,7 +320,7 @@ const AnnotationSetList = ({
           })}
         </ul>
         <button
-          className="group relative w-full btn"
+          className={tw(`group relative w-full btn`)}
           onClick={() => {
             setAnnotations([]);
             setComponentDefinition("");
@@ -315,7 +328,7 @@ const AnnotationSetList = ({
           }}
         >
           <svg
-            className="h-4 w-4 octicon mr-1"
+            className={tw(`h-4 w-4 octicon mr-1`)}
             viewBox="0 0 20 20"
             fill="currentColor"
           >

--- a/src/blocks/file-blocks/charts/Chart.tsx
+++ b/src/blocks/file-blocks/charts/Chart.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import {
   Area,
   AreaChart,
@@ -52,7 +53,7 @@ export function Chart({
   if (!ChartComponent) return null;
 
   return (
-    <div className="w-full h-full">
+    <div className={tw(`w-full h-full`)}>
       <ChartComponent
         data={sortedData}
         xMetric={parsedXMetric}

--- a/src/blocks/file-blocks/charts/ErrorBoundary.tsx
+++ b/src/blocks/file-blocks/charts/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import React from "react";
 
 export class ErrorBoundary extends React.Component {
@@ -21,7 +22,7 @@ export class ErrorBoundary extends React.Component {
     // @ts-ignore
     if (this.state.hasError) {
       return (
-        <div className="flex flex-col">
+        <div className={tw(`flex flex-col`)}>
           <h1>Something went wrong.</h1>
           <p>
             {/* @ts-ignore */}

--- a/src/blocks/file-blocks/charts/index.tsx
+++ b/src/blocks/file-blocks/charts/index.tsx
@@ -1,6 +1,6 @@
 import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
-import { ActionList, ActionMenu } from "@primer/react";
+import { ActionList, ActionMenu, Text } from "@primer/react";
 import { parse } from "papaparse";
 import { useEffect, useMemo, useState } from "react";
 // @ts-ignore: we need to specify the file extension
@@ -144,16 +144,29 @@ const Select = ({
         {label}: {value}
       </ActionMenu.Button>
       <ActionMenu.Overlay>
-        <ActionList>
-          {options.map((option) => (
-            <ActionList.Item key={option} onSelect={() => onChange(option)}>
-              <ActionList.LeadingVisual>
-                {option === value ? <CheckIcon /> : null}
-              </ActionList.LeadingVisual>
-              {option}
-            </ActionList.Item>
-          ))}
-        </ActionList>
+        {options.length ? (
+          <ActionList>
+            {options.map((option) => (
+              <ActionList.Item key={option} onSelect={() => onChange(option)}>
+                <ActionList.LeadingVisual>
+                  {option === value ? <CheckIcon /> : null}
+                </ActionList.LeadingVisual>
+                {option}
+              </ActionList.Item>
+            ))}
+          </ActionList>
+        ) : (
+          <Text
+            color="fg.muted"
+            textAlign="center"
+            fontStyle="italic"
+            display="block"
+            mx="auto"
+            my="2"
+          >
+            No options
+          </Text>
+        )}
       </ActionMenu.Overlay>
     </ActionMenu>
   );

--- a/src/blocks/file-blocks/charts/index.tsx
+++ b/src/blocks/file-blocks/charts/index.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Chart } from "./Chart.tsx";
 // @ts-ignore: we need to specify the file extension
 import { ErrorBoundary } from "./ErrorBoundary.tsx";
+import { Button } from "@primer/react";
 
 export default function (props: FileBlockProps) {
   const { content, metadata, onUpdateMetadata } = props;
@@ -55,8 +56,9 @@ export default function (props: FileBlockProps) {
           options={savedChartConfigs}
         />
         {activeChartConfigIndex !== -1 ? (
-          <button
-            className={tw(`btn ml-2 btn-danger`)}
+          <Button
+            variant="danger"
+            className={tw(`ml-2`)}
             onClick={() => {
               const newMetadata = {
                 configs: savedChartConfigs.filter(
@@ -67,10 +69,10 @@ export default function (props: FileBlockProps) {
             }}
           >
             Delete config
-          </button>
+          </Button>
         ) : (
-          <button
-            className={tw(`btn ml-2`)}
+          <Button
+            className={tw(`ml-2`)}
             onClick={() => {
               const newMetadata = {
                 configs: [...savedChartConfigs, activeChartConfig],
@@ -79,7 +81,7 @@ export default function (props: FileBlockProps) {
             }}
           >
             Save config
-          </button>
+          </Button>
         )}
         <div className={tw(`ml-auto flex items-center flex-wrap`)}>
           <div className={tw(`mr-2`)}>

--- a/src/blocks/file-blocks/charts/index.tsx
+++ b/src/blocks/file-blocks/charts/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
 import { parse } from "papaparse";
 import { useEffect, useMemo, useState } from "react";
@@ -45,8 +46,8 @@ export default function (props: FileBlockProps) {
   }, [keys.join(","), savedChartConfigs.join(",")]);
 
   return (
-    <div className="w-full h-full">
-      <div className="d-flex p-3">
+    <div className={tw(`w-full h-full`)}>
+      <div className={tw(`d-flex p-3`)}>
         <Select
           label="saved charts"
           value={activeChartConfig}
@@ -55,7 +56,7 @@ export default function (props: FileBlockProps) {
         />
         {activeChartConfigIndex !== -1 ? (
           <button
-            className="btn ml-2 btn-danger"
+            className={tw(`btn ml-2 btn-danger`)}
             onClick={() => {
               const newMetadata = {
                 configs: savedChartConfigs.filter(
@@ -69,7 +70,7 @@ export default function (props: FileBlockProps) {
           </button>
         ) : (
           <button
-            className="btn ml-2"
+            className={tw(`btn ml-2`)}
             onClick={() => {
               const newMetadata = {
                 configs: [...savedChartConfigs, activeChartConfig],
@@ -80,8 +81,8 @@ export default function (props: FileBlockProps) {
             Save config
           </button>
         )}
-        <div className="ml-auto flex items-center flex-wrap">
-          <div className="mr-2">
+        <div className={tw(`ml-auto flex items-center flex-wrap`)}>
+          <div className={tw(`mr-2`)}>
             <Select
               label="x metric"
               value={xMetric}
@@ -89,7 +90,7 @@ export default function (props: FileBlockProps) {
               options={keys}
             />
           </div>
-          <div className="mr-2">
+          <div className={tw(`mr-2`)}>
             <Select
               label="y metric"
               value={yMetric}
@@ -106,7 +107,7 @@ export default function (props: FileBlockProps) {
         </div>
       </div>
 
-      <div className="w-full">
+      <div className={tw(`w-full`)}>
         <ErrorBoundary>
           <Chart
             data={data}
@@ -136,23 +137,27 @@ const Select = ({
   onChange: (value: string) => void;
 }) => {
   return (
-    <details className="dropdown details-reset details-overlay d-inline-block">
-      <summary className="btn" aria-haspopup="true">
+    <details
+      className={tw(`dropdown details-reset details-overlay d-inline-block`)}
+    >
+      <summary className={tw(`btn`)} aria-haspopup="true">
         {label}: {value}
-        <span className="dropdown-caret border-black"></span>
+        <span className={tw(`dropdown-caret border-black`)}></span>
       </summary>
-      <div className="SelectMenu">
-        <div className="SelectMenu-modal">
-          <div className="SelectMenu-list">
+      <div className={tw(`SelectMenu`)}>
+        <div className={tw(`SelectMenu-modal`)}>
+          <div className={tw(`SelectMenu-list`)}>
             {canBeEmpty && (
               <button
-                className="SelectMenu-item"
+                className={tw(`SelectMenu-item`)}
                 role="menuitemcheckbox"
                 aria-checked={!value}
                 onClick={(e) => onChange("")}
               >
                 <svg
-                  className="SelectMenu-icon SelectMenu-icon--check octicon octicon-check"
+                  className={tw(
+                    `SelectMenu-icon SelectMenu-icon--check octicon octicon-check`
+                  )}
                   viewBox="0 0 16 16"
                   width="16"
                   height="16"
@@ -170,12 +175,14 @@ const Select = ({
             {options.map((option) => (
               <button
                 aria-checked={option === value}
-                className="SelectMenu-item"
+                className={tw(`SelectMenu-item`)}
                 role="menuitemcheckbox"
                 onClick={(e) => onChange(option)}
               >
                 <svg
-                  className="SelectMenu-icon SelectMenu-icon--check octicon octicon-check"
+                  className={tw(
+                    `SelectMenu-icon SelectMenu-icon--check octicon octicon-check`
+                  )}
                   viewBox="0 0 16 16"
                   width="16"
                   height="16"

--- a/src/blocks/file-blocks/charts/index.tsx
+++ b/src/blocks/file-blocks/charts/index.tsx
@@ -1,5 +1,6 @@
 import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
+import { ActionList, ActionMenu } from "@primer/react";
 import { parse } from "papaparse";
 import { useEffect, useMemo, useState } from "react";
 // @ts-ignore: we need to specify the file extension
@@ -48,7 +49,7 @@ export default function (props: FileBlockProps) {
 
   return (
     <div className={tw(`w-full h-full`)}>
-      <div className={tw(`d-flex p-3`)}>
+      <div className={tw(`flex p-3`)}>
         <Select
           label="saved charts"
           value={activeChartConfig}
@@ -129,80 +130,29 @@ const Select = ({
   label,
   value,
   options,
-  canBeEmpty,
   onChange,
 }: {
   label: string;
   value: string;
   options: string[];
-  canBeEmpty?: boolean;
   onChange: (value: string) => void;
 }) => {
   return (
-    <details
-      className={tw(`dropdown details-reset details-overlay d-inline-block`)}
-    >
-      <summary className={tw(`btn`)} aria-haspopup="true">
+    <ActionMenu>
+      <ActionMenu.Button>
         {label}: {value}
-        <span className={tw(`dropdown-caret border-black`)}></span>
-      </summary>
-      <div className={tw(`SelectMenu`)}>
-        <div className={tw(`SelectMenu-modal`)}>
-          <div className={tw(`SelectMenu-list`)}>
-            {canBeEmpty && (
-              <button
-                className={tw(`SelectMenu-item`)}
-                role="menuitemcheckbox"
-                aria-checked={!value}
-                onClick={(e) => onChange("")}
-              >
-                <svg
-                  className={tw(
-                    `SelectMenu-icon SelectMenu-icon--check octicon octicon-check`
-                  )}
-                  viewBox="0 0 16 16"
-                  width="16"
-                  height="16"
-                >
-                  {" "}
-                  <path
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                    d="M13.78 4.22C13.9204 4.36062 13.9993 4.55125 13.9993 4.75C13.9993 4.94875 13.9204 5.13937 13.78 5.28L6.53 12.53C6.38937 12.6704 6.19875 12.7493 6 12.7493C5.80125 12.7493 5.61062 12.6704 5.47 12.53L2.22 9.28C2.08752 9.13782 2.0154 8.94978 2.01882 8.75547C2.02225 8.56117 2.10096 8.37579 2.23838 8.23837C2.37579 8.10096 2.56118 8.02225 2.75548 8.01882C2.94978 8.01539 3.13782 8.08752 3.28 8.22L6 10.94L12.72 4.22C12.8606 4.07955 13.0512 4.00066 13.25 4.00066C13.4487 4.00066 13.6394 4.07955 13.78 4.22Z"
-                  ></path>
-                </svg>
-                --
-              </button>
-            )}
-            {options.map((option) => (
-              <button
-                aria-checked={option === value}
-                className={tw(`SelectMenu-item`)}
-                role="menuitemcheckbox"
-                onClick={(e) => onChange(option)}
-              >
-                <svg
-                  className={tw(
-                    `SelectMenu-icon SelectMenu-icon--check octicon octicon-check`
-                  )}
-                  viewBox="0 0 16 16"
-                  width="16"
-                  height="16"
-                >
-                  {" "}
-                  <path
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                    d="M13.78 4.22C13.9204 4.36062 13.9993 4.55125 13.9993 4.75C13.9993 4.94875 13.9204 5.13937 13.78 5.28L6.53 12.53C6.38937 12.6704 6.19875 12.7493 6 12.7493C5.80125 12.7493 5.61062 12.6704 5.47 12.53L2.22 9.28C2.08752 9.13782 2.0154 8.94978 2.01882 8.75547C2.02225 8.56117 2.10096 8.37579 2.23838 8.23837C2.37579 8.10096 2.56118 8.02225 2.75548 8.01882C2.94978 8.01539 3.13782 8.08752 3.28 8.22L6 10.94L12.72 4.22C12.8606 4.07955 13.0512 4.00066 13.25 4.00066C13.4487 4.00066 13.6394 4.07955 13.78 4.22Z"
-                  ></path>
-                </svg>
-                {option}
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
-    </details>
+      </ActionMenu.Button>
+      <ActionMenu.Overlay>
+        <ActionList>
+          {options.map((option) => (
+            <ActionList.Item key={option} onSelect={() => onChange(option)}>
+              {/* OcticonCheck */}
+              {option}
+            </ActionList.Item>
+          ))}
+        </ActionList>
+      </ActionMenu.Overlay>
+    </ActionMenu>
   );
 };
 

--- a/src/blocks/file-blocks/charts/index.tsx
+++ b/src/blocks/file-blocks/charts/index.tsx
@@ -8,6 +8,7 @@ import { Chart } from "./Chart.tsx";
 // @ts-ignore: we need to specify the file extension
 import { ErrorBoundary } from "./ErrorBoundary.tsx";
 import { Button } from "@primer/react";
+import { CheckIcon } from "@primer/octicons-react";
 
 export default function (props: FileBlockProps) {
   const { content, metadata, onUpdateMetadata } = props;
@@ -146,7 +147,9 @@ const Select = ({
         <ActionList>
           {options.map((option) => (
             <ActionList.Item key={option} onSelect={() => onChange(option)}>
-              {/* OcticonCheck */}
+              <ActionList.LeadingVisual>
+                {option === value ? <CheckIcon /> : null}
+              </ActionList.LeadingVisual>
               {option}
             </ActionList.Item>
           ))}

--- a/src/blocks/file-blocks/code/index.tsx
+++ b/src/blocks/file-blocks/code/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import "./style.css";
 import React from "react";
 import { FileBlockProps } from "@githubnext/utils";
@@ -130,7 +131,9 @@ export default function (props: FileBlockProps) {
 
   return (
     <div
-      className="position-relative width-full height-full overflow-auto height-full"
+      className={tw(
+        `position-relative width-full height-full overflow-auto height-full`
+      )}
       key={path}
       ref={editorRef}
     />

--- a/src/blocks/file-blocks/code/index.tsx
+++ b/src/blocks/file-blocks/code/index.tsx
@@ -131,9 +131,7 @@ export default function (props: FileBlockProps) {
 
   return (
     <div
-      className={tw(
-        `position-relative width-full height-full overflow-auto height-full`
-      )}
+      className={tw(`relative w-full h-full overflow-auto`)}
       key={path}
       ref={editorRef}
     />

--- a/src/blocks/file-blocks/css.tsx
+++ b/src/blocks/file-blocks/css.tsx
@@ -8,7 +8,13 @@ export default function (props: FileBlockProps) {
   const { content } = props;
 
   const { tree, flattenedRules, widelyApplicableAttributes } = useMemo(() => {
-    const tree = toJSON(content);
+    console.log(content);
+    let tree = { children: [] };
+    try {
+      tree = toJSON(content);
+    } catch (e) {
+      console.log(e);
+    }
     // const rules = getRulesFromTreeItem(tree)
     let flattenedRules = {} as any;
     Object.keys(tree.children).forEach((key) => {

--- a/src/blocks/file-blocks/css.tsx
+++ b/src/blocks/file-blocks/css.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { useEffect, useMemo } from "react";
 // @ts-ignore: no types
 import { toJSON } from "cssjson";
@@ -31,7 +32,7 @@ export default function (props: FileBlockProps) {
 
   return (
     <div
-      className="p-8"
+      className={tw(`p-8`)}
       style={{
         background:
           flattenedRules?.["body"]?.background ||
@@ -72,15 +73,15 @@ const TreeItem = ({
   }
 
   return (
-    <div className="py-3 flex">
-      <div className="font-mono w-40 sticky top-2 pt-2 h-8 flex-none">
+    <div className={tw(`py-3 flex`)}>
+      <div className={tw(`font-mono w-40 sticky top-2 pt-2 h-8 flex-none`)}>
         {selector}
       </div>
       <div>
         {cssVariableNames.map((variable) => {
           return (
-            <div className="flex items-center text-xs m-1" key={variable}>
-              <div className="font-mono flex-none w-60">{variable}</div>
+            <div className={tw(`flex items-center text-xs m-1`)} key={variable}>
+              <div className={tw(`font-mono flex-none w-60`)}>{variable}</div>
               <Attribute value={attributes[variable]} />
             </div>
           );
@@ -100,14 +101,14 @@ const Attribute = ({ value }: { value: string }) => {
   if (isColor)
     return (
       <div
-        className="h-6 w-6 rounded"
+        className={tw(`h-6 w-6 rounded`)}
         style={{
           backgroundColor: value,
         }}
       />
     );
   return (
-    <div className="p-1 bg-gray-100 rounded text-gray-800 font-mono">
+    <div className={tw(`p-1 bg-gray-100 rounded text-gray-800 font-mono`)}>
       {value}
     </div>
   );

--- a/src/blocks/file-blocks/edit/index.css
+++ b/src/blocks/file-blocks/edit/index.css
@@ -1,3 +1,7 @@
+.wrapper {
+  grid-rows: 7em 1fr;
+}
+
 .hljs {
   color: #24292e;
   background: #ffffff;

--- a/src/blocks/file-blocks/edit/index.tsx
+++ b/src/blocks/file-blocks/edit/index.tsx
@@ -35,10 +35,9 @@ export default function (props: FileBlockProps) {
 
   return (
     <div
-      id="example-block-summarize-block"
-      className={tw(
-        `h-full w-full relative grid grid-cols-2 gap-2 grid-rows-[7em,1fr]`
-      )}
+      className={
+        "wrapper" + tw(`h-full w-full relative grid grid-cols-2 gap-2`)
+      }
     >
       <form
         className={`relative px-5 py-2 flex flex-col justify-end ${

--- a/src/blocks/file-blocks/edit/index.tsx
+++ b/src/blocks/file-blocks/edit/index.tsx
@@ -8,6 +8,7 @@ import "react-diff-view/style/index.css";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { diffAsText } from "unidiff";
 import "./index.css";
+import { Button, FormControl, TextInput } from "@primer/react";
 
 export default function (props: FileBlockProps) {
   const { content, context, onUpdateContent } = props;
@@ -54,25 +55,29 @@ export default function (props: FileBlockProps) {
           setIsLoading(false);
         }}
       >
-        <label className={tw(`font-normal`)}>
-          How would you like to edit this code?
-        </label>
-        <div className={tw(`flex items-center mt-1`)}>
-          <input
-            className={tw(`w-full p-2 form-control`)}
-            type="text"
-            value={instruction}
-            disabled={isLoading}
-            onChange={(e) => {
-              setInstruction(e.target.value);
-            }}
-          />
-          <button disabled={isLoading} className={tw(`btn ml-1 self-stretch`)}>
-            {newContent ? "Re-generate modified code" : "Get modified code"}
-            <span className={tw(`ml-2`)}>
-              <RocketIcon />
-            </span>
-          </button>
+        <div className={tw(`flex items-end mt-1`)}>
+          <FormControl>
+            <FormControl.Label>
+              How would you like to edit the code?
+            </FormControl.Label>
+            <TextInput
+              value={instruction}
+              disabled={isLoading}
+              onChange={(e) => {
+                setInstruction(e.target.value);
+              }}
+            />
+          </FormControl>
+
+          <div>
+            <Button
+              trailingIcon={RocketIcon}
+              disabled={isLoading}
+              className={tw(`btn ml-1 self-stretch`)}
+            >
+              {newContent ? "Re-generate modified code" : "Get modified code"}
+            </Button>
+          </div>
         </div>
       </form>
 

--- a/src/blocks/file-blocks/edit/index.tsx
+++ b/src/blocks/file-blocks/edit/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { FileBlockProps, getLanguageFromFilename } from "@githubnext/utils";
 import { RocketIcon } from "@primer/octicons-react";
 import axios from "axios";
@@ -34,7 +35,9 @@ export default function (props: FileBlockProps) {
   return (
     <div
       id="example-block-summarize-block"
-      className="h-full w-full relative grid grid-cols-2 gap-2 grid-rows-[7em,1fr]"
+      className={tw(
+        `h-full w-full relative grid grid-cols-2 gap-2 grid-rows-[7em,1fr]`
+      )}
     >
       <form
         className={`relative px-5 py-2 flex flex-col justify-end ${
@@ -51,12 +54,12 @@ export default function (props: FileBlockProps) {
           setIsLoading(false);
         }}
       >
-        <label className="font-normal">
+        <label className={tw(`font-normal`)}>
           How would you like to edit this code?
         </label>
-        <div className="flex items-center mt-1">
+        <div className={tw(`flex items-center mt-1`)}>
           <input
-            className="w-full p-2 form-control"
+            className={tw(`w-full p-2 form-control`)}
             type="text"
             value={instruction}
             disabled={isLoading}
@@ -64,21 +67,21 @@ export default function (props: FileBlockProps) {
               setInstruction(e.target.value);
             }}
           />
-          <button disabled={isLoading} className="btn ml-1 self-stretch">
+          <button disabled={isLoading} className={tw(`btn ml-1 self-stretch`)}>
             {newContent ? "Re-generate modified code" : "Get modified code"}
-            <span className="ml-2">
+            <span className={tw(`ml-2`)}>
               <RocketIcon />
             </span>
           </button>
         </div>
       </form>
 
-      <div className="flex items-end px-5 py-2">
+      <div className={tw(`flex items-end px-5 py-2`)}>
         {newContent && (
-          <div className="w-full flex justify-between">
-            <div className="text-gray-500">Proposed code</div>
+          <div className={tw(`w-full flex justify-between`)}>
+            <div className={tw(`text-gray-500`)}>Proposed code</div>
             <button
-              className="btn btn-primary"
+              className={tw(`btn btn-primary`)}
               onClick={() => {
                 onUpdateContent(newContent);
               }}
@@ -90,8 +93,8 @@ export default function (props: FileBlockProps) {
       </div>
 
       {newContent ? (
-        <div className="col-span-2">
-          <div className="w-full">
+        <div className={tw(`col-span-2`)}>
+          <div className={tw(`w-full`)}>
             {hunks?.[0]?.hunks?.map((hunk: Hunk) => (
               <HunkComponent
                 key={hunk.content}
@@ -102,13 +105,13 @@ export default function (props: FileBlockProps) {
           </div>
         </div>
       ) : (
-        <pre className="px-5 py-3 text-left">
+        <pre className={tw(`px-5 py-3 text-left`)}>
           <SyntaxHighlighter
             language={syntaxHighlighterLanguageMap[language] || "javascript"}
             useInlineStyles={false}
             showLineNumbers={false}
             lineNumberStyle={{ opacity: 0.45 }}
-            className="!bg-transparent"
+            className={tw(`!bg-transparent`)}
             wrapLines
             wrapLongLines
           >
@@ -127,7 +130,7 @@ const syntaxHighlighterLanguageMap = {
 
 const HunkComponent = ({ hunk, language }: { hunk: any; language: string }) => {
   return (
-    <pre className="px-5 py-3 text-left">
+    <pre className={tw(`px-5 py-3 text-left`)}>
       {hunk.changes.map((change: Hunk["change"], i: number) => (
         <Change key={i} change={change} language={language} />
       ))}
@@ -137,7 +140,7 @@ const HunkComponent = ({ hunk, language }: { hunk: any; language: string }) => {
 
 const Change = ({ change, language }: { change: Hunk; language: string }) => {
   return (
-    <div className="grid grid-cols-2">
+    <div className={tw(`grid grid-cols-2`)}>
       <SyntaxHighlighter
         language={syntaxHighlighterLanguageMap[language] || "javascript"}
         useInlineStyles={false}

--- a/src/blocks/file-blocks/edit/index.tsx
+++ b/src/blocks/file-blocks/edit/index.tsx
@@ -73,7 +73,7 @@ export default function (props: FileBlockProps) {
             <Button
               trailingIcon={RocketIcon}
               disabled={isLoading}
-              className={tw(`btn ml-1 self-stretch`)}
+              className={tw(`ml-1 self-stretch`)}
             >
               {newContent ? "Re-generate modified code" : "Get modified code"}
             </Button>
@@ -85,14 +85,14 @@ export default function (props: FileBlockProps) {
         {newContent && (
           <div className={tw(`w-full flex justify-between`)}>
             <div className={tw(`text-gray-500`)}>Proposed code</div>
-            <button
-              className={tw(`btn btn-primary`)}
+            <Button
+              variant="primary"
               onClick={() => {
                 onUpdateContent(newContent);
               }}
             >
               Save changes
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/src/blocks/file-blocks/excalidraw/index.tsx
+++ b/src/blocks/file-blocks/excalidraw/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
 import { useEffect, useState } from "react";
 import "./style.css";
@@ -34,7 +35,11 @@ export default function (props: FileBlockProps) {
   const ExcalidrawComponent = excalModule ? excalModule.default : null;
 
   return (
-    <div className="width-full" key={context.path} style={{ height: "100vh" }}>
+    <div
+      className={tw(`width-full`)}
+      key={context.path}
+      style={{ height: "100vh" }}
+    >
       {ExcalidrawComponent && (
         <ExcalidrawComponent
           viewModeEnabled={!isEditable}

--- a/src/blocks/file-blocks/explain/explanation.tsx
+++ b/src/blocks/file-blocks/explain/explanation.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import axios from "axios";
 import { useQuery } from "react-query";
 import type { Explanation } from ".";
@@ -23,23 +24,25 @@ export function ExplanationComponent(props: {
 
   return (
     <>
-      <div className="sticky top-0 z-10 pb-2 bg-white">
-        <p className="text-xs font-mono">
+      <div className={tw(`sticky top-0 z-10 pb-2 bg-white`)}>
+        <p className={tw(`text-xs font-mono`)}>
           Explanation for{" "}
-          <span className="font-bold">
+          <span className={tw(`font-bold`)}>
             L{explanation.start}:L
             {explanation.end}
           </span>
         </p>
       </div>
 
-      <div className="relative">
+      <div className={tw(`relative`)}>
         {status === "loading" && (
-          <p className="text-xs  font-mono animate-pulse">Loading...</p>
+          <p className={tw(`text-xs  font-mono animate-pulse`)}>Loading...</p>
         )}
         {status === "success" && data && (
-          <div className="pb-2">
-            <p className="text-xs whitespace-pre-line font-mono">{data}</p>
+          <div className={tw(`pb-2`)}>
+            <p className={tw(`text-xs whitespace-pre-line font-mono`)}>
+              {data}
+            </p>
           </div>
         )}
       </div>

--- a/src/blocks/file-blocks/explain/index.tsx
+++ b/src/blocks/file-blocks/explain/index.tsx
@@ -1,6 +1,5 @@
 import { tw } from "twind";
 import { FileBlockProps, getLanguageFromFilename } from "@githubnext/utils";
-import { ThemeProvider } from "@primer/react";
 import { useCallback, useState } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import SyntaxHighlighter from "react-syntax-highlighter";
@@ -171,9 +170,7 @@ export default function (props: FileBlockProps) {
   const queryClient = new QueryClient();
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <BlockInner {...props} />
-      </ThemeProvider>
+      <BlockInner {...props} />
     </QueryClientProvider>
   );
 }

--- a/src/blocks/file-blocks/explain/index.tsx
+++ b/src/blocks/file-blocks/explain/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { FileBlockProps, getLanguageFromFilename } from "@githubnext/utils";
 import { ThemeProvider } from "@primer/react";
 import { useCallback, useState } from "react";
@@ -101,12 +102,14 @@ function BlockInner(props: FileBlockProps) {
   }, [content, context, start, end]);
 
   return (
-    <div className="relative">
+    <div className={tw(`relative`)}>
       {Object.entries(explanations).map(([line, explanation]) => {
         return (
           <div
             key={line}
-            className="px-3 overflow-y-auto break-words absolute bg-white w-[260px] right-0 z-10"
+            className={tw(
+              `px-3 overflow-y-auto break-words absolute bg-white w-[260px] right-0 z-10`
+            )}
             style={{
               top: (explanation.start - 1) * 18 - 2,
               height: (explanation.end - explanation.start + 1) * 18,
@@ -120,10 +123,10 @@ function BlockInner(props: FileBlockProps) {
           </div>
         );
       })}
-      <div className="h-full explain-block overflow-auto pl-10 relative">
+      <div className={tw(`h-full explain-block overflow-auto pl-10 relative`)}>
         {start && end && (
           <div
-            className="z-20 absolute"
+            className={tw(`z-20 absolute`)}
             style={{ top: (start - 1) * 18 - 4, left: 0 }}
           >
             <LineMenu
@@ -139,7 +142,7 @@ function BlockInner(props: FileBlockProps) {
           language={syntaxHighlighterLanguageMap[language] || "javascript"}
           useInlineStyles={false}
           wrapLines
-          className="!bg-transparent syntax-highlighter-block"
+          className={tw(`!bg-transparent syntax-highlighter-block`)}
           lineProps={(lineNumber) => {
             const isHighlighted =
               start && end && lineNumber >= start && lineNumber <= end;

--- a/src/blocks/file-blocks/flat.tsx
+++ b/src/blocks/file-blocks/flat.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
 import { Grid } from "@githubocto/flat-ui";
 import { csvFormat, csvParseRows } from "d3";
@@ -29,7 +30,7 @@ export default function (props: FileBlockProps) {
   );
 
   return (
-    <div className="height-full d-flex flex-column flex-1">
+    <div className={tw(`height-full d-flex flex-column flex-1`)}>
       <Grid
         data={data}
         diffData={originalData}

--- a/src/blocks/file-blocks/flat.tsx
+++ b/src/blocks/file-blocks/flat.tsx
@@ -30,7 +30,7 @@ export default function (props: FileBlockProps) {
   );
 
   return (
-    <div className={tw(`height-full d-flex flex-column flex-1`)}>
+    <div className={tw(`h-full flex flex-col flex-1`)}>
       <Grid
         data={data}
         diffData={originalData}

--- a/src/blocks/file-blocks/geojson.tsx
+++ b/src/blocks/file-blocks/geojson.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
 import {
   Fragment,
@@ -61,10 +62,10 @@ export default function (props: FileBlockProps) {
   );
 
   return (
-    <div className="relative w-full h-full overflow-auto">
+    <div className={tw(`relative w-full h-full overflow-auto`)}>
       {isMounted && (
         <RMap
-          className="w-full h-full min-h-[10em] min-w-[10em]"
+          className={tw(`w-full h-full min-h-[10em] min-w-[10em]`)}
           initial={{
             center: [0, 0],
             zoom: 1,
@@ -165,8 +166,12 @@ export default function (props: FileBlockProps) {
       )}
 
       {hoveredFeature && (
-        <div className="absolute top-2 left-2 max-h-[85%] shadow-xl overflow-auto p-4 bg-white border border-gray-200">
-          <div className="grid grid-cols-[6em,1fr]">
+        <div
+          className={tw(
+            `absolute top-2 left-2 max-h-[85%] shadow-xl overflow-auto p-4 bg-white border border-gray-200`
+          )}
+        >
+          <div className={tw(`grid grid-cols-[6em,1fr]`)}>
             {hoveredFeature.values_ &&
               Object.keys(hoveredFeature.values_).map(
                 (key: string, i: number) => {
@@ -176,13 +181,17 @@ export default function (props: FileBlockProps) {
                   return (
                     <Fragment key={i}>
                       <div
-                        className="flex-none text-xs text-gray-600 max-w-[15em] truncate mr-1 min-w-[5em]"
+                        className={tw(
+                          `flex-none text-xs text-gray-600 max-w-[15em] truncate mr-1 min-w-[5em]`
+                        )}
                         title={key}
                       >
                         {key}
                       </div>
                       <div
-                        className="flex-1 text-xs text-gray-900 font-mono max-w-[20em] truncate min-w-[10em]"
+                        className={tw(
+                          `flex-1 text-xs text-gray-900 font-mono max-w-[20em] truncate min-w-[10em]`
+                        )}
                         title={currentValue}
                       >
                         {isEditable && typeof currentValue === "string" ? (
@@ -227,7 +236,7 @@ export default function (props: FileBlockProps) {
                             }}
                           />
                         ) : (
-                          <div className="py-1 px-2">
+                          <div className={tw(`py-1 px-2`)}>
                             {JSON.stringify(hoveredFeature.values_[key])}
                           </div>
                         )}
@@ -274,7 +283,7 @@ const EditableText = ({
   }, [isEditing]);
 
   return (
-    <div className="">
+    <div className={tw(``)}>
       {isEditing && (
         <form
           onSubmit={(e) => {
@@ -286,7 +295,7 @@ const EditableText = ({
           <input
             autoFocus
             ref={inputElement}
-            className="w-full py-1 px-2"
+            className={tw(`w-full py-1 px-2`)}
             type="text"
             value={inputValue}
             onChange={onChangeInput}
@@ -304,7 +313,7 @@ const EditableText = ({
       )}
       {!isEditing && (
         <button
-          className="py-1 px-2 hover:bg-gray-100"
+          className={tw(`py-1 px-2 hover:bg-gray-100`)}
           onClick={() => {
             setIsEditing(true);
             setInputValue(value);

--- a/src/blocks/file-blocks/live-markdown/CodeSandbox.tsx
+++ b/src/blocks/file-blocks/live-markdown/CodeSandbox.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { ReactNode, useEffect, useState } from "react";
 import LZString from "lz-string";
 
@@ -55,10 +56,10 @@ export const CodeSandbox = ({
   }, []);
 
   return (
-    <div className="w-full h-full mt-3 mb-10">
+    <div className={tw(`w-full h-full mt-3 mb-10`)}>
       {!!url && (
         <iframe
-          className="w-full outline-none"
+          className={tw(`w-full outline-none`)}
           style={{
             height,
           }}

--- a/src/blocks/file-blocks/live-markdown/ErrorBoundary.tsx
+++ b/src/blocks/file-blocks/live-markdown/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { tw } from "twind";
 
 export class ErrorBoundary extends React.Component {
   // @ts-ignore
@@ -21,7 +22,7 @@ export class ErrorBoundary extends React.Component {
     // @ts-ignore
     if (this.state.hasError) {
       return (
-        <div className="flex flex-col">
+        <div className={tw(`flex flex-col`)}>
           <h1>Something went wrong.</h1>
           <p>
             {/* @ts-ignore */}

--- a/src/blocks/file-blocks/live-markdown/index.tsx
+++ b/src/blocks/file-blocks/live-markdown/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
 // @ts-ignore
 import MDX from "@mdx-js/runtime";
@@ -56,9 +57,13 @@ export default function (props: FileBlockProps) {
 
   return (
     <MarkdownContext.Provider value={repoInfo} key={content}>
-      <div className="w-full h-full flex items-stretch overflow-hidden">
-        <div className="flex-1 markdown-body p-6 pb-40 overflow-y-auto whitespace-pre-wrap">
-          <div className="max-w-[60em] mx-auto">
+      <div className={tw(`w-full h-full flex items-stretch overflow-hidden`)}>
+        <div
+          className={tw(
+            `flex-1 markdown-body p-6 pb-40 overflow-y-auto whitespace-pre-wrap`
+          )}
+        >
+          <div className={tw(`max-w-[60em] mx-auto`)}>
             <ErrorBoundary key={content}>
               <MDX components={components} scope={repoInfo}>
                 {sanitizedContent}
@@ -86,7 +91,7 @@ const components = {
   }) {
     const match = /language-(\w+)/.exec(className || "");
     return !inline && match ? (
-      <div className="code">
+      <div className={tw(`code`)}>
         <SyntaxHighlighter language={match[1]}>
           {String(children).replace(/\n$/, "")}
         </SyntaxHighlighter>
@@ -128,39 +133,43 @@ function Issues({ num = 3 }) {
 
   if (!filteredIssues.length) {
     return (
-      <div className="w-full h-10 items-center justify-center italic text-center pt-2 text-gray-500">
+      <div
+        className={tw(
+          `w-full h-10 items-center justify-center italic text-center pt-2 text-gray-500`
+        )}
+      >
         No issues found
       </div>
     );
   }
 
   return (
-    <div className="mt-3 mb-6">
-      <div className="flex space-x-2 flex-wrap">
+    <div className={tw(`mt-3 mb-6`)}>
+      <div className={tw(`flex space-x-2 flex-wrap`)}>
         {filteredIssues.map((issue) => (
           <Box
             bg="canvas.subtle"
             p={3}
             key={issue.id}
-            className="relative flex-1 min-w-[19em] m-1"
+            className={tw(`relative flex-1 min-w-[19em] m-1`)}
           >
-            <div className="flex justify-between items-start">
-              <a className="block !text-black" href={issue.html_url}>
+            <div className={tw(`flex justify-between items-start`)}>
+              <a className={tw(`block !text-black`)} href={issue.html_url}>
                 {issue.title}
               </a>
               <StateLabel
                 // @ts-ignore
                 status={issueStateToStatusMap[issue.state] || ""}
                 variant="small"
-                className=""
+                className={tw(``)}
               >
                 {issue.state}
               </StateLabel>
             </div>
-            <div className="mt-1 text-sm italic text-gray-600">
+            <div className={tw(`mt-1 text-sm italic text-gray-600`)}>
               Last update {formatDate(new Date(issue.updated_at))}
             </div>
-            {/* <MDX className="whitespace-pre-wrap truncate">{issue.body}</MDX> */}
+            {/* <MDX className={tw(`whitespace-pre-wrap truncate`)}>{issue.body}</MDX> */}
           </Box>
         ))}
       </div>
@@ -173,31 +182,35 @@ function Releases({ num = 3 }) {
 
   if (!filteredReleases.length) {
     return (
-      <div className="w-full h-10 items-center justify-center italic text-center pt-2 text-gray-500">
+      <div
+        className={tw(
+          `w-full h-10 items-center justify-center italic text-center pt-2 text-gray-500`
+        )}
+      >
         No releases found
       </div>
     );
   }
 
   return (
-    <div className="mt-3 mb-6">
-      <div className="flex space-x-2 flex-wrap">
+    <div className={tw(`mt-3 mb-6`)}>
+      <div className={tw(`flex space-x-2 flex-wrap`)}>
         {filteredReleases.map((release) => (
           <Box
             bg="canvas.subtle"
             p={3}
             key={release.id}
-            className="relative flex-1 min-w-[19em] m-1"
+            className={tw(`relative flex-1 min-w-[19em] m-1`)}
           >
-            <div className="flex justify-between items-center">
-              <a className="block !text-black" href={release.html_url}>
+            <div className={tw(`flex justify-between items-center`)}>
+              <a className={tw(`block !text-black`)} href={release.html_url}>
                 {release.tag_name}
               </a>
             </div>
-            <div className="mt-1 text-sm italic text-gray-600">
+            <div className={tw(`mt-1 text-sm italic text-gray-600`)}>
               {formatDate(new Date(release.published_at))}
             </div>
-            {/* <MDX className="whitespace-pre-wrap truncate">{issue.body}</MDX> */}
+            {/* <MDX className={tw(`whitespace-pre-wrap truncate`)}>{issue.body}</MDX> */}
           </Box>
         ))}
       </div>
@@ -210,34 +223,38 @@ function Commits({ num = 2 }) {
 
   if (!filteredCommits.length) {
     return (
-      <div className="w-full h-10 items-center justify-center italic text-center pt-2 text-gray-500">
+      <div
+        className={tw(
+          `w-full h-10 items-center justify-center italic text-center pt-2 text-gray-500`
+        )}
+      >
         No commits found
       </div>
     );
   }
 
   return (
-    <div className="mt-3 mb-6">
-      <div className="flex flex-wrap">
+    <div className={tw(`mt-3 mb-6`)}>
+      <div className={tw(`flex flex-wrap`)}>
         {filteredCommits.map((commit) => (
           <Box
             p={3}
             key={commit.sha}
-            className="relative flex-1 min-w-[19em] m-1 bg-gray-100"
+            className={tw(`relative flex-1 min-w-[19em] m-1 bg-gray-100`)}
           >
-            <div className="flex justify-between items-center">
-              <a className="block !text-black" href={commit.html_url}>
+            <div className={tw(`flex justify-between items-center`)}>
+              <a className={tw(`block !text-black`)} href={commit.html_url}>
                 {commit.commit.message}
               </a>
             </div>
             {/* author */}
-            <Box className="flex items-center mt-3">
-              <Avatar src={commit.author.avatar_url} className="mr-2" />
-              <div className="flex-1 flex items-center justify-between">
-                <div className="text-sm text-gray-600">
+            <Box className={tw(`flex items-center mt-3`)}>
+              <Avatar src={commit.author.avatar_url} className={tw(`mr-2`)} />
+              <div className={tw(`flex-1 flex items-center justify-between`)}>
+                <div className={tw(`text-sm text-gray-600`)}>
                   {commit.author.login}
                 </div>
-                <div className="mt-1 text-sm italic text-gray-600">
+                <div className={tw(`mt-1 text-sm italic text-gray-600`)}>
                   {formatDate(new Date(commit.commit.author.date))}
                 </div>
               </div>

--- a/src/blocks/file-blocks/live-markdown/index.tsx
+++ b/src/blocks/file-blocks/live-markdown/index.tsx
@@ -2,7 +2,7 @@ import { tw } from "twind";
 import { FileBlockProps } from "@githubnext/utils";
 // @ts-ignore
 import MDX from "@mdx-js/runtime";
-import { Avatar, Box, StateLabel } from "@primer/components";
+import { Avatar, Box, StateLabel } from "@primer/react";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { CodeSandbox } from "./CodeSandbox";

--- a/src/blocks/file-blocks/poll.tsx
+++ b/src/blocks/file-blocks/poll.tsx
@@ -1,19 +1,5 @@
 import { tw } from "twind";
-import { useMemo, useState } from "react";
-// import { useUpdateFileContents, useFileContent } from "hooks";
-// import { BlockProps } from ".";
-
 import { FileBlockProps } from "@githubnext/utils"; // to import tailwind css
-
-interface PollOptions {
-  text: string;
-  votes: number;
-}
-
-type Poll = {
-  poll: string; // title
-  options: PollOptions[];
-};
 
 export default function (props: FileBlockProps) {
   const { content, isEditable, onUpdateContent } = props;

--- a/src/blocks/file-blocks/poll.tsx
+++ b/src/blocks/file-blocks/poll.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { useMemo, useState } from "react";
 // import { useUpdateFileContents, useFileContent } from "hooks";
 // import { BlockProps } from ".";
@@ -29,7 +30,7 @@ export default function (props: FileBlockProps) {
 
   if (!poll || !poll.options)
     return (
-      <div className="py-20 text-gray-500 w-full text-center italic">
+      <div className={tw(`py-20 text-gray-500 w-full text-center italic`)}>
         No poll data found
       </div>
     );
@@ -37,29 +38,32 @@ export default function (props: FileBlockProps) {
   const totalVotes = poll.options.reduce((acc, cur) => acc + cur.votes, 0);
 
   return (
-    <div className="w-full m-2 py-20 flex flex-col items-center">
+    <div className={tw(`w-full m-2 py-20 flex flex-col items-center`)}>
       {poll.poll}
       {poll.options.map((option, index) => {
         const percent = Math.floor((option.votes / totalVotes) * 100);
         return (
-          <div key={index} className="my-2">
-            <div className="font-bold">{option.text}</div>
-            <div className="flex row items-center">
-              <div className="w-80 border border-gray-200 mr-2">
+          <div key={index} className={tw(`my-2`)}>
+            <div className={tw(`font-bold`)}>{option.text}</div>
+            <div className={tw(`flex row items-center`)}>
+              <div className={tw(`w-80 border border-gray-200 mr-2`)}>
                 <div
-                  className="bg-blue-400 h-3"
+                  className={tw(`bg-blue-400 h-3`)}
                   style={{ width: `${percent}%` }}
                 ></div>
               </div>
-              <span className="mr-2">{percent}%</span>
-              <span className="font-light mr-2">{option.votes} votes</span>
+              <span className={tw(`mr-2`)}>{percent}%</span>
+              <span className={tw(`font-light mr-2`)}>
+                {option.votes} votes
+              </span>
               <button
                 disabled={!isEditable}
-                className={
-                  "bg-transparent hover:bg-blue-500 text-blue-400 hover:text-white px-2 border border-blue-500 hover:border-transparent rounded" +
-                  (!isEditable ? " pointer-events-none" : "")
-                }
-                onClick={onClick(index)}
+                className={tw(
+                  `bg-transparent hover:bg-blue-500 text-blue-400 hover:text-white px-2 border border-blue-500 hover:border-transparent rounded ${
+                    !isEditable ? "pointer-events-none" : ""
+                  }`
+                )}
+                onClick={() => onClick(index)}
               >
                 Vote
               </button>

--- a/src/blocks/file-blocks/sentence-encoder.tsx
+++ b/src/blocks/file-blocks/sentence-encoder.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import "@tensorflow/tfjs";
 import { FileBlockProps } from "@githubnext/utils";
 import { useEffect, useState } from "react";
@@ -115,13 +116,15 @@ export default function (props: FileBlockProps) {
   return (
     <>
       {model ? (
-        <div className="m-4">
-          <div className="flex row mb-8">
-            <h2 className="text-lg text-gray-900 font-semibold mr-4">
+        <div className={tw(`m-4`)}>
+          <div className={tw(`flex row mb-8`)}>
+            <h2 className={tw(`text-lg text-gray-900 font-semibold mr-4`)}>
               Sentence Encoder
             </h2>
             <button
-              className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-2 rounded text-sm"
+              className={tw(
+                `bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-2 rounded text-sm`
+              )}
               onClick={() => setEditView(!editView)}
             >
               {editView ? "Back to data results" : "Try your own question"}
@@ -130,15 +133,17 @@ export default function (props: FileBlockProps) {
 
           {editView ? (
             <div>
-              <div className="mb-3 pt-0">
+              <div className={tw(`mb-3 pt-0`)}>
                 <input
                   onChange={(e) => setCustomQuestion(e.target.value)}
                   type="text"
                   placeholder="Question"
-                  className="px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full"
+                  className={tw(
+                    `px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full`
+                  )}
                 />
               </div>
-              <div className="mb-3 pt-0">
+              <div className={tw(`mb-3 pt-0`)}>
                 <input
                   onChange={(e) => {
                     customAnswers[0] = e.target.value;
@@ -146,10 +151,12 @@ export default function (props: FileBlockProps) {
                   }}
                   type="text"
                   placeholder="Answer 1"
-                  className="px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full"
+                  className={tw(
+                    `px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full`
+                  )}
                 />
               </div>
-              <div className="mb-3 pt-0">
+              <div className={tw(`mb-3 pt-0`)}>
                 <input
                   onChange={(e) => {
                     customAnswers[1] = e.target.value;
@@ -157,10 +164,12 @@ export default function (props: FileBlockProps) {
                   }}
                   type="text"
                   placeholder="Answer 2"
-                  className="px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full"
+                  className={tw(
+                    `px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full`
+                  )}
                 />
               </div>
-              <div className="mb-3 pt-0">
+              <div className={tw(`mb-3 pt-0`)}>
                 <input
                   onChange={(e) => {
                     customAnswers[2] = e.target.value;
@@ -168,16 +177,20 @@ export default function (props: FileBlockProps) {
                   }}
                   type="text"
                   placeholder="Answer 3"
-                  className="px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full"
+                  className={tw(
+                    `px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full`
+                  )}
                 />
               </div>
               {computedQuery ? (
-                <div className="mb-3">
+                <div className={tw(`mb-3`)}>
                   <Table query={computedQuery}></Table>
                 </div>
               ) : null}
               <button
-                className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+                className={tw(
+                  `bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded`
+                )}
                 onClick={computeScore}
               >
                 Compute score
@@ -197,7 +210,7 @@ export default function (props: FileBlockProps) {
           )}
         </div>
       ) : (
-        <div className="m-4">Loading...</div>
+        <div className={tw(`m-4`)}>Loading...</div>
       )}
     </>
   );
@@ -211,12 +224,12 @@ function Table(props: TableProps) {
   const query = props.query;
 
   return (
-    <table className="table-auto">
+    <table className={tw(`table-auto`)}>
       <thead>
         <tr>
-          <th className="px-4 py-2 text-gray-700">Question</th>
-          <th className="px-4 py-2 text-gray-700">Answer</th>
-          <th className="px-4 py-2 text-gray-700">Score</th>
+          <th className={tw(`px-4 py-2 text-gray-700`)}>Question</th>
+          <th className={tw(`px-4 py-2 text-gray-700`)}>Answer</th>
+          <th className={tw(`px-4 py-2 text-gray-700`)}>Score</th>
         </tr>
       </thead>
       <tbody>
@@ -229,10 +242,18 @@ function Table(props: TableProps) {
             >
               {query.query}
             </td>
-            <td className="border border-gray-500 px-4 py-2 text-gray-700 font-medium">
+            <td
+              className={tw(
+                `border border-gray-500 px-4 py-2 text-gray-700 font-medium`
+              )}
+            >
               {response.response}
             </td>
-            <td className="border border-gray-500 px-4 py-2 text-gray-700 font-medium">
+            <td
+              className={tw(
+                `border border-gray-500 px-4 py-2 text-gray-700 font-medium`
+              )}
+            >
               {response.score.toFixed(2)}
             </td>
           </tr>

--- a/src/blocks/file-blocks/summarize/index.tsx
+++ b/src/blocks/file-blocks/summarize/index.tsx
@@ -1,10 +1,11 @@
-import { tw } from "twind";
-import { useEffect, useState } from "react";
-import axios from "axios";
-import SyntaxHighlighter from "react-syntax-highlighter";
 import { FileBlockProps, getLanguageFromFilename } from "@githubnext/utils";
-import "./index.css";
+import { FoldIcon, UnfoldIcon } from "@primer/octicons-react";
 import { Button } from "@primer/react";
+import axios from "axios";
+import { useEffect, useState } from "react";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { tw } from "twind";
+import "./index.css";
 
 export default function (props: FileBlockProps) {
   const { content, context } = props;
@@ -61,26 +62,12 @@ export default function (props: FileBlockProps) {
         >
           {isCollapsed ? (
             <>
-              <svg
-                className={tw(`inline-block mr-1 -ml-1`)}
-                viewBox="0 0 16 16"
-                width="16"
-                height="16"
-              >
-                <path d="M8.177.677l2.896 2.896a.25.25 0 01-.177.427H8.75v1.25a.75.75 0 01-1.5 0V4H5.104a.25.25 0 01-.177-.427L7.823.677a.25.25 0 01.354 0zM7.25 10.75a.75.75 0 011.5 0V12h2.146a.25.25 0 01.177.427l-2.896 2.896a.25.25 0 01-.354 0l-2.896-2.896A.25.25 0 015.104 12H7.25v-1.25zm-5-2a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM6 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 016 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM12 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 0112 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5z"></path>
-              </svg>
+              <UnfoldIcon className={tw(`inline-block mr-1 -ml-1`)} />
               Expand sections
             </>
           ) : (
             <>
-              <svg
-                className={tw(`inline-block mr-1 -ml-1`)}
-                viewBox="0 0 16 16"
-                width="16"
-                height="16"
-              >
-                <path d="M10.896 2H8.75V.75a.75.75 0 00-1.5 0V2H5.104a.25.25 0 00-.177.427l2.896 2.896a.25.25 0 00.354 0l2.896-2.896A.25.25 0 0010.896 2zM8.75 15.25a.75.75 0 01-1.5 0V14H5.104a.25.25 0 01-.177-.427l2.896-2.896a.25.25 0 01.354 0l2.896 2.896a.25.25 0 01-.177.427H8.75v1.25zm-6.5-6.5a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM6 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 016 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM12 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 0112 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5z"></path>
-              </svg>
+              <FoldIcon className={tw(`inline-block mr-1 -ml-1`)} />
               Collapse sections
             </>
           )}

--- a/src/blocks/file-blocks/summarize/index.tsx
+++ b/src/blocks/file-blocks/summarize/index.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { FileBlockProps, getLanguageFromFilename } from "@githubnext/utils";
 import "./index.css";
+import { Button } from "@primer/react";
 
 export default function (props: FileBlockProps) {
   const { content, context } = props;
@@ -52,40 +53,40 @@ export default function (props: FileBlockProps) {
 
   return (
     <div className={tw(`h-full w-full relative`)}>
-      <button
-        className={tw(
-          `btn flex items-center position-absolute top-2 right-2 z-10`
-        )}
-        onClick={() => {
-          setIsCollapsed(!isCollapsed);
-        }}
-      >
-        {isCollapsed ? (
-          <>
-            <svg
-              className={tw(`inline-block mr-1 -ml-1`)}
-              viewBox="0 0 16 16"
-              width="16"
-              height="16"
-            >
-              <path d="M8.177.677l2.896 2.896a.25.25 0 01-.177.427H8.75v1.25a.75.75 0 01-1.5 0V4H5.104a.25.25 0 01-.177-.427L7.823.677a.25.25 0 01.354 0zM7.25 10.75a.75.75 0 011.5 0V12h2.146a.25.25 0 01.177.427l-2.896 2.896a.25.25 0 01-.354 0l-2.896-2.896A.25.25 0 015.104 12H7.25v-1.25zm-5-2a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM6 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 016 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM12 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 0112 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5z"></path>
-            </svg>
-            Expand sections
-          </>
-        ) : (
-          <>
-            <svg
-              className={tw(`inline-block mr-1 -ml-1`)}
-              viewBox="0 0 16 16"
-              width="16"
-              height="16"
-            >
-              <path d="M10.896 2H8.75V.75a.75.75 0 00-1.5 0V2H5.104a.25.25 0 00-.177.427l2.896 2.896a.25.25 0 00.354 0l2.896-2.896A.25.25 0 0010.896 2zM8.75 15.25a.75.75 0 01-1.5 0V14H5.104a.25.25 0 01-.177-.427l2.896-2.896a.25.25 0 01.354 0l2.896 2.896a.25.25 0 01-.177.427H8.75v1.25zm-6.5-6.5a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM6 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 016 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM12 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 0112 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5z"></path>
-            </svg>
-            Collapse sections
-          </>
-        )}
-      </button>
+      <div className={tw(`absolute top-2 right-2 z-10`)}>
+        <Button
+          onClick={() => {
+            setIsCollapsed(!isCollapsed);
+          }}
+        >
+          {isCollapsed ? (
+            <>
+              <svg
+                className={tw(`inline-block mr-1 -ml-1`)}
+                viewBox="0 0 16 16"
+                width="16"
+                height="16"
+              >
+                <path d="M8.177.677l2.896 2.896a.25.25 0 01-.177.427H8.75v1.25a.75.75 0 01-1.5 0V4H5.104a.25.25 0 01-.177-.427L7.823.677a.25.25 0 01.354 0zM7.25 10.75a.75.75 0 011.5 0V12h2.146a.25.25 0 01.177.427l-2.896 2.896a.25.25 0 01-.354 0l-2.896-2.896A.25.25 0 015.104 12H7.25v-1.25zm-5-2a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM6 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 016 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM12 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 0112 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5z"></path>
+              </svg>
+              Expand sections
+            </>
+          ) : (
+            <>
+              <svg
+                className={tw(`inline-block mr-1 -ml-1`)}
+                viewBox="0 0 16 16"
+                width="16"
+                height="16"
+              >
+                <path d="M10.896 2H8.75V.75a.75.75 0 00-1.5 0V2H5.104a.25.25 0 00-.177.427l2.896 2.896a.25.25 0 00.354 0l2.896-2.896A.25.25 0 0010.896 2zM8.75 15.25a.75.75 0 01-1.5 0V14H5.104a.25.25 0 01-.177-.427l2.896-2.896a.25.25 0 01.354 0l2.896 2.896a.25.25 0 01-.177.427H8.75v1.25zm-6.5-6.5a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM6 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 016 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5zM12 8a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5A.75.75 0 0112 8zm2.25.75a.75.75 0 000-1.5h-.5a.75.75 0 000 1.5h.5z"></path>
+              </svg>
+              Collapse sections
+            </>
+          )}
+        </Button>
+      </div>
+
       <div
         className={tw(
           `h-full w-full d-flex flex-column bg-gray-50 overflow-auto`

--- a/src/blocks/file-blocks/summarize/index.tsx
+++ b/src/blocks/file-blocks/summarize/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { useEffect, useState } from "react";
 import axios from "axios";
 import SyntaxHighlighter from "react-syntax-highlighter";
@@ -50,9 +51,11 @@ export default function (props: FileBlockProps) {
   }, [content]);
 
   return (
-    <div className="h-full w-full relative">
+    <div className={tw(`h-full w-full relative`)}>
       <button
-        className="btn flex items-center position-absolute top-2 right-2 z-10"
+        className={tw(
+          `btn flex items-center position-absolute top-2 right-2 z-10`
+        )}
         onClick={() => {
           setIsCollapsed(!isCollapsed);
         }}
@@ -60,7 +63,7 @@ export default function (props: FileBlockProps) {
         {isCollapsed ? (
           <>
             <svg
-              className="inline-block mr-1 -ml-1"
+              className={tw(`inline-block mr-1 -ml-1`)}
               viewBox="0 0 16 16"
               width="16"
               height="16"
@@ -72,7 +75,7 @@ export default function (props: FileBlockProps) {
         ) : (
           <>
             <svg
-              className="inline-block mr-1 -ml-1"
+              className={tw(`inline-block mr-1 -ml-1`)}
               viewBox="0 0 16 16"
               width="16"
               height="16"
@@ -83,13 +86,17 @@ export default function (props: FileBlockProps) {
           </>
         )}
       </button>
-      <div className="h-full w-full d-flex flex-column bg-gray-50 overflow-auto">
+      <div
+        className={tw(
+          `h-full w-full d-flex flex-column bg-gray-50 overflow-auto`
+        )}
+      >
         {/* <p className={`px-6 pt-3 whitespace-pre-wrap ${fileSummary ? "" : "text-gray-400"}`}>
         Briefly, this code will {fileSummary || "..."}
         </p> */}
-        <pre className="divide-y divide-gray-200 text-left">
+        <pre className={tw(`divide-y divide-gray-200 text-left`)}>
           {!sections.length && (
-            <div className="text-center text-gray-500 italic py-10">
+            <div className={tw(`text-center text-gray-500 italic py-10`)}>
               Loading...
             </div>
           )}
@@ -149,7 +156,7 @@ const Section = ({
         setIsCollapsedLocally(!isCollapsedLocally);
       }}
     >
-      <div className="relative overflow-hidden border-r border-gray-200">
+      <div className={tw(`relative overflow-hidden border-r border-gray-200`)}>
         <div
           className={`px-5 py-3 text-base overflow-x-auto !bg-transparent top-0 ${
             isCollapsedLocally ? "absolute" : ""
@@ -160,7 +167,7 @@ const Section = ({
             useInlineStyles={false}
             showLineNumbers={false}
             lineNumberStyle={{ opacity: 0.45 }}
-            className="!bg-transparent"
+            className={tw(`!bg-transparent`)}
             wrapLines
             wrapLongLines
           >
@@ -169,19 +176,27 @@ const Section = ({
         </div>
         {isCollapsedLocally && (
           // fade out to bottom
-          <div className="absolute bottom-0 left-0 right-0 h-[3em] bg-gradient-to-b from-transparent to-gray-50 hover:to-white z-10" />
+          <div
+            className={tw(
+              `absolute bottom-0 left-0 right-0 h-[3em] bg-gradient-to-b from-transparent to-gray-50 hover:to-white z-10`
+            )}
+          />
         )}
       </div>
-      <div className="px-5 py-3 text-gray-800 text-sm font-sans min-h-[5em]">
+      <div
+        className={tw(`px-5 py-3 text-gray-800 text-sm font-sans min-h-[5em]`)}
+      >
         {hasValidName && (
-          <div className="font-mono text-xs font-medium mb-1 text-gray-500">
+          <div
+            className={tw(`font-mono text-xs font-medium mb-1 text-gray-500`)}
+          >
             {name}
           </div>
         )}
         {explanation === undefined ? (
-          <div className="text-gray-300 italic">Loading...</div>
+          <div className={tw(`text-gray-300 italic`)}>Loading...</div>
         ) : (
-          <div className="">{explanation || ""}</div>
+          <div className={tw(``)}>{explanation || ""}</div>
         )}
       </div>
     </div>

--- a/src/blocks/file-blocks/summarize/index.tsx
+++ b/src/blocks/file-blocks/summarize/index.tsx
@@ -88,9 +88,7 @@ export default function (props: FileBlockProps) {
       </div>
 
       <div
-        className={tw(
-          `h-full w-full d-flex flex-column bg-gray-50 overflow-auto`
-        )}
+        className={tw(`h-full w-full flex flex-col bg-gray-50 overflow-auto`)}
       >
         {/* <p className={`px-6 pt-3 whitespace-pre-wrap ${fileSummary ? "" : "text-gray-400"}`}>
         Briefly, this code will {fileSummary || "..."}

--- a/src/blocks/folder-blocks/code-tour/index.tsx
+++ b/src/blocks/folder-blocks/code-tour/index.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Select from "react-select";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import "./style.css";
+import { Button, FormControl, TextInput } from "@primer/react";
 
 export default function (props: FolderBlockProps) {
   const {
@@ -216,21 +217,22 @@ const TourControls = ({
         </form>
       ) : (
         <div className={tw(`grid grid-cols-2 gap-2`)}>
-          <button
-            className={tw(`mt-3 btn w-full`)}
+          <Button
+            className={tw(`mt-3 w-full`)}
             onClick={() => {
               setSteps([...steps, newStep]);
               setSelectedStepIndex(steps.length);
             }}
           >
             + Add Step
-          </button>
-          <button
-            className={tw(`mt-3 btn btn-primary w-full`)}
+          </Button>
+          <Button
+            className={tw(`mt-3 w-full`)}
+            variant="primary"
             onClick={() => setIsSaving(true)}
           >
             Save tour
-          </button>
+          </Button>
         </div>
       )}
     </>
@@ -424,34 +426,38 @@ const StepContent = ({
     <div className={tw(`h-full flex flex-col`)}>
       {isEditing ? (
         <div className={tw(`w-full`)}>
-          <label className={tw(``)}>Step name</label>
-          <input
-            className={tw(`form-control py-2 w-full`)}
-            value={step.name}
-            onChange={(e) => onChange({ ...step, name: e.target.value })}
-          />
-          {/* <textarea value={step.description} onChange={(e) => onChange({ ...step, description: e.target.value })} className={tw(`w-full h-40 py-3 px-5  border border-gray-300 rounded`)} /> */}
+          <FormControl>
+            <FormControl.Label>Step name</FormControl.Label>
+            <TextInput
+              className={tw(`w-full`)}
+              value={step.name}
+              onChange={(e) => onChange({ ...step, name: e.target.value })}
+            />
+          </FormControl>
 
           <div className={tw(`flex mt-2`)}>
             <div className={tw(`flex-1 min-w-0`)}>
-              <label className={tw(``)}>Path</label>
-              <Select
-                options={pathOptions}
-                value={pathOptions.find((d) => d.value === step.path)}
-                styles={selectStyles}
-                onChange={(newValue: any) => {
-                  const path = newValue.value;
-                  onChange({ ...step, path });
-                }}
-              />
+              <FormControl>
+                <FormControl.Label>Path</FormControl.Label>
+                <Select
+                  options={pathOptions}
+                  value={pathOptions.find((d) => d.value === step.path)}
+                  styles={selectStyles}
+                  onChange={(newValue: any) => {
+                    const path = newValue.value;
+                    onChange({ ...step, path });
+                  }}
+                />
+              </FormControl>
             </div>
             <div className={tw(`flex-none min-w-0 w-40 ml-1`)}>
-              <label className={tw(``)}>Query</label>
-              <input
-                className={tw(`form-control py-2`)}
-                value={localQuery}
-                onChange={(e) => setLocalQuery(e.target.value)}
-              />
+              <FormControl>
+                <FormControl.Label>Query</FormControl.Label>
+                <TextInput
+                  value={localQuery}
+                  onChange={(e) => setLocalQuery(e.target.value)}
+                />
+              </FormControl>
             </div>
           </div>
         </div>

--- a/src/blocks/folder-blocks/code-tour/index.tsx
+++ b/src/blocks/folder-blocks/code-tour/index.tsx
@@ -106,14 +106,14 @@ export default function (props: FolderBlockProps) {
                 placeholder="Select tour"
               />
             </div>
-            <button
-              className={tw(`btn px-2`)}
+            <Button
+              className={tw(`px-2`)}
               onClick={() => {
                 setSelectedTourIndex(-1);
               }}
             >
               +
-            </button>
+            </Button>
           </div>
 
           <div
@@ -203,16 +203,18 @@ const TourControls = ({
             onChange={(e) => setName(e.target.value)}
           />
           <div className={tw(`mt-1 grid grid-cols-2 gap-2`)}>
-            <button
-              className={tw(`btn w-full`)}
+            <Button
+              className={tw(`w-full`)}
               onClick={() => {
                 setIsSaving(false);
               }}
               type="button"
             >
               Cancel
-            </button>
-            <button className={tw(`btn btn-primary w-full`)}>Save</button>
+            </Button>
+            <Button variant="primary" className={tw(`w-full`)}>
+              Save
+            </Button>
           </div>
         </form>
       ) : (
@@ -300,9 +302,10 @@ const Step = ({
         {step.path}
       </div>
       {!!onDelete && (
-        <button
+        <Button
+          variant="danger"
           className={tw(
-            `!absolute top-1/2 right-0 px-2 flex items-center justify-center btn btn-danger transform -translate-x-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus:opacity-100`
+            `!absolute top-1/2 right-0 px-2 flex items-center justify-center transform -translate-x-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus:opacity-100`
           )}
           onClick={(e) => {
             e.stopPropagation();
@@ -320,7 +323,7 @@ const Step = ({
               clipRule="evenodd"
             />
           </svg>
-        </button>
+        </Button>
       )}
     </button>
   );

--- a/src/blocks/folder-blocks/code-tour/index.tsx
+++ b/src/blocks/folder-blocks/code-tour/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import cq from "@fullstackio/cq";
 import { FolderBlockProps, getLanguageFromFilename } from "@githubnext/utils";
 import debounce from "lodash/debounce";
@@ -68,9 +69,9 @@ export default function (props: FolderBlockProps) {
   }, [usedPaths.join(",")]);
 
   return (
-    <div className="w-full h-full" id="example-block-code-block">
-      <div className="flex w-full h-full overflow-x-hidden">
-        <div className="flex-1 h-full min-w-0 p-5 pb-0">
+    <div className={tw(`w-full h-full`)} id="example-block-code-block">
+      <div className={tw(`flex w-full h-full overflow-x-hidden`)}>
+        <div className={tw(`flex-1 h-full min-w-0 p-5 pb-0`)}>
           {!!steps[selectedStepIndex] && (
             <StepContent
               index={selectedStepIndex}
@@ -87,12 +88,16 @@ export default function (props: FolderBlockProps) {
           )}
         </div>
 
-        <div className="w-80 h-full overflow-y-auto p-5 pl-0">
-          <div className="uppercase mb-1 text-sm text-gray-600 tracking-widest">
+        <div className={tw(`w-80 h-full overflow-y-auto p-5 pl-0`)}>
+          <div
+            className={tw(
+              `uppercase mb-1 text-sm text-gray-600 tracking-widest`
+            )}
+          >
             Code Tour
           </div>
-          <div className="grid grid-cols-7 gap-2 mb-4">
-            <div className="col-span-6">
+          <div className={tw(`grid grid-cols-7 gap-2 mb-4`)}>
+            <div className={tw(`col-span-6`)}>
               <Select
                 options={tourOptions}
                 value={tourOptions[selectedTourIndex] || null}
@@ -101,7 +106,7 @@ export default function (props: FolderBlockProps) {
               />
             </div>
             <button
-              className="btn px-2"
+              className={tw(`btn px-2`)}
               onClick={() => {
                 setSelectedTourIndex(-1);
               }}
@@ -110,7 +115,11 @@ export default function (props: FolderBlockProps) {
             </button>
           </div>
 
-          <div className="uppercase mb-1 text-sm text-gray-600 tracking-widest">
+          <div
+            className={tw(
+              `uppercase mb-1 text-sm text-gray-600 tracking-widest`
+            )}
+          >
             Steps
           </div>
           <TourSteps
@@ -176,23 +185,25 @@ const TourControls = ({
     <>
       {isSaving ? (
         <form
-          className="mt-2"
+          className={tw(`mt-2`)}
           onSubmit={(e) => {
             e.preventDefault();
             onSave(name);
           }}
         >
-          <label className="">Tour name</label>
+          <label className={tw(``)}>Tour name</label>
           <input
-            className="flex-1 w-full py-2 px-3 border border-gray-400 rounded-md"
+            className={tw(
+              `flex-1 w-full py-2 px-3 border border-gray-400 rounded-md`
+            )}
             type="text"
             autoFocus
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
-          <div className="mt-1 grid grid-cols-2 gap-2">
+          <div className={tw(`mt-1 grid grid-cols-2 gap-2`)}>
             <button
-              className="btn w-full"
+              className={tw(`btn w-full`)}
               onClick={() => {
                 setIsSaving(false);
               }}
@@ -200,13 +211,13 @@ const TourControls = ({
             >
               Cancel
             </button>
-            <button className="btn btn-primary w-full">Save</button>
+            <button className={tw(`btn btn-primary w-full`)}>Save</button>
           </div>
         </form>
       ) : (
-        <div className="grid grid-cols-2 gap-2">
+        <div className={tw(`grid grid-cols-2 gap-2`)}>
           <button
-            className="mt-3 btn w-full"
+            className={tw(`mt-3 btn w-full`)}
             onClick={() => {
               setSteps([...steps, newStep]);
               setSelectedStepIndex(steps.length);
@@ -215,7 +226,7 @@ const TourControls = ({
             + Add Step
           </button>
           <button
-            className="mt-3 btn btn-primary w-full"
+            className={tw(`mt-3 btn btn-primary w-full`)}
             onClick={() => setIsSaving(true)}
           >
             Save tour
@@ -240,8 +251,8 @@ const TourSteps = ({
   isEditing: boolean;
 }) => {
   return (
-    <div className="w-full">
-      <div className="divide-y divide-gray-200">
+    <div className={tw(`w-full`)}>
+      <div className={tw(`divide-y divide-gray-200`)}>
         {steps.map((step, index) => (
           <Step
             key={index}
@@ -282,17 +293,25 @@ const Step = ({
       }`}
       onClick={onSelect}
     >
-      <div className="font-semibold mb-1">{step.name}</div>
-      <div className="opacity-60 font-mono text-xs truncate">{step.path}</div>
+      <div className={tw(`font-semibold mb-1`)}>{step.name}</div>
+      <div className={tw(`opacity-60 font-mono text-xs truncate`)}>
+        {step.path}
+      </div>
       {!!onDelete && (
         <button
-          className="!absolute top-1/2 right-0 px-2 flex items-center justify-center btn btn-danger transform -translate-x-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus:opacity-100"
+          className={tw(
+            `!absolute top-1/2 right-0 px-2 flex items-center justify-center btn btn-danger transform -translate-x-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus:opacity-100`
+          )}
           onClick={(e) => {
             e.stopPropagation();
             onDelete();
           }}
         >
-          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+          <svg
+            className={tw(`w-4 h-4`)}
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
             <path
               fillRule="evenodd"
               d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
@@ -402,20 +421,20 @@ const StepContent = ({
   }, [index]);
 
   return (
-    <div className="h-full flex flex-col">
+    <div className={tw(`h-full flex flex-col`)}>
       {isEditing ? (
-        <div className="w-full">
-          <label className="">Step name</label>
+        <div className={tw(`w-full`)}>
+          <label className={tw(``)}>Step name</label>
           <input
-            className="form-control py-2 w-full"
+            className={tw(`form-control py-2 w-full`)}
             value={step.name}
             onChange={(e) => onChange({ ...step, name: e.target.value })}
           />
-          {/* <textarea value={step.description} onChange={(e) => onChange({ ...step, description: e.target.value })} className="w-full h-40 py-3 px-5  border border-gray-300 rounded" /> */}
+          {/* <textarea value={step.description} onChange={(e) => onChange({ ...step, description: e.target.value })} className={tw(`w-full h-40 py-3 px-5  border border-gray-300 rounded`)} /> */}
 
-          <div className="flex mt-2">
-            <div className="flex-1 min-w-0">
-              <label className="">Path</label>
+          <div className={tw(`flex mt-2`)}>
+            <div className={tw(`flex-1 min-w-0`)}>
+              <label className={tw(``)}>Path</label>
               <Select
                 options={pathOptions}
                 value={pathOptions.find((d) => d.value === step.path)}
@@ -426,10 +445,10 @@ const StepContent = ({
                 }}
               />
             </div>
-            <div className="flex-none min-w-0 w-40 ml-1">
-              <label className="">Query</label>
+            <div className={tw(`flex-none min-w-0 w-40 ml-1`)}>
+              <label className={tw(``)}>Query</label>
               <input
-                className="form-control py-2"
+                className={tw(`form-control py-2`)}
                 value={localQuery}
                 onChange={(e) => setLocalQuery(e.target.value)}
               />
@@ -437,17 +456,19 @@ const StepContent = ({
           </div>
         </div>
       ) : (
-        <div className="flex flex-col">
-          <div className="font-semibold text-lg mb-1">{step.name}</div>
-          <div className="opacity-60 font-mono text-xs truncate mb-2">
+        <div className={tw(`flex flex-col`)}>
+          <div className={tw(`font-semibold text-lg mb-1`)}>{step.name}</div>
+          <div className={tw(`opacity-60 font-mono text-xs truncate mb-2`)}>
             {step.path}
           </div>
         </div>
       )}
 
-      <div className="flex flex-1 overflow-y-auto mt-1">
+      <div className={tw(`flex flex-1 overflow-y-auto mt-1`)}>
         <div
-          className="flex-1 h-full flex flex-col overflow-y-auto overflow-x-hidden"
+          className={tw(
+            `flex-1 h-full flex flex-col overflow-y-auto overflow-x-hidden`
+          )}
           ref={codeContainer}
         >
           <Code
@@ -517,7 +538,7 @@ const Code = ({
   }, [highlightRangeStart, highlightRangeEnd]);
 
   return (
-    <div className="code text-sm w-full overflow-x-auto" ref={container}>
+    <div className={tw(`code text-sm w-full overflow-x-auto`)} ref={container}>
       <SyntaxHighlighter
         language={language}
         useInlineStyles={false}

--- a/src/blocks/folder-blocks/dashboard/index.tsx
+++ b/src/blocks/folder-blocks/dashboard/index.tsx
@@ -2,6 +2,8 @@ import { tw } from "twind";
 import { useEffect, useMemo, useState } from "react";
 import { FolderBlockProps } from "@githubnext/utils";
 import Select from "react-select";
+import { Box, Button, IconButton } from "@primer/react";
+import { TrashIcon } from "@primer/octicons-react";
 
 // Note: We're using a BlockComponent prop here to create nested Blocks.
 // This is only implemented for our own example Blocks, to showcase the concept.
@@ -71,9 +73,12 @@ export default function (props: FolderBlockProps) {
       }}
     >
       {blocks.map((block: any, index: number) => (
-        <div
-          className={tw(`Box`)}
-          style={{
+        <Box
+          borderColor="border.default"
+          borderWidth={1}
+          borderStyle="solid"
+          borderRadius={4}
+          sx={{
             margin: "0.5em",
             flex: "1",
             minHeight: 0,
@@ -82,7 +87,14 @@ export default function (props: FolderBlockProps) {
             overflow: "hidden",
           }}
         >
-          <div key={index} className={tw(`Box-header d-flex py-2`)}>
+          <Box
+            bg="canvas.subtle"
+            borderColor="border.default"
+            borderStyle="solid"
+            borderBottomWidth={1}
+            key={index}
+            className={tw(`Box-header flex p-2`)}
+          >
             <div>
               <Select
                 options={pathOptions}
@@ -122,35 +134,22 @@ export default function (props: FolderBlockProps) {
                 }}
               />
             </div>
-            <button
+            <div
               className={tw(
-                `btn btn-danger d-flex flex-items-center mx-1 flex-self-stretch `
+                `flex items-center justify-center ml-2 flex-shrink-0`
               )}
-              style={{
-                flex: "none",
-              }}
-              onClick={() => {
-                const newBlocks = [...blocks];
-                newBlocks.splice(index, 1);
-                setBlocks(newBlocks);
-              }}
             >
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 16 16"
-                className={tw(`bi bi-trash`)}
-                fill="currentColor"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z" />
-                <path
-                  fillRule="evenodd"
-                  d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4L4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"
-                />
-              </svg>
-            </button>
-          </div>
+              <IconButton
+                variant="danger"
+                onClick={() => {
+                  const newBlocks = [...blocks];
+                  newBlocks.splice(index, 1);
+                  setBlocks(newBlocks);
+                }}
+                icon={TrashIcon}
+              ></IconButton>
+            </div>
+          </Box>
           {!block.block ? (
             <div
               style={{
@@ -179,11 +178,10 @@ export default function (props: FolderBlockProps) {
               )}
             </div>
           )}
-        </div>
+        </Box>
       ))}
-      <button
-        className={tw(`btn`)}
-        style={{
+      <Button
+        sx={{
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
@@ -218,7 +216,7 @@ export default function (props: FolderBlockProps) {
             d="M7.5 8a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1H8.5V12a.5.5 0 0 1-1 0V8z"
           />
         </svg>
-      </button>
+      </Button>
       {isDirty && (
         <button
           style={{

--- a/src/blocks/folder-blocks/dashboard/index.tsx
+++ b/src/blocks/folder-blocks/dashboard/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { useEffect, useMemo, useState } from "react";
 import { FolderBlockProps } from "@githubnext/utils";
 import Select from "react-select";
@@ -71,7 +72,7 @@ export default function (props: FolderBlockProps) {
     >
       {blocks.map((block: any, index: number) => (
         <div
-          className="Box"
+          className={tw(`Box`)}
           style={{
             margin: "0.5em",
             flex: "1",
@@ -81,7 +82,7 @@ export default function (props: FolderBlockProps) {
             overflow: "hidden",
           }}
         >
-          <div key={index} className="Box-header d-flex py-2">
+          <div key={index} className={tw(`Box-header d-flex py-2`)}>
             <div>
               <Select
                 options={pathOptions}
@@ -122,7 +123,9 @@ export default function (props: FolderBlockProps) {
               />
             </div>
             <button
-              className="btn btn-danger d-flex flex-items-center mx-1 flex-self-stretch "
+              className={tw(
+                `btn btn-danger d-flex flex-items-center mx-1 flex-self-stretch `
+              )}
               style={{
                 flex: "none",
               }}
@@ -136,7 +139,7 @@ export default function (props: FolderBlockProps) {
                 width="1em"
                 height="1em"
                 viewBox="0 0 16 16"
-                className="bi bi-trash"
+                className={tw(`bi bi-trash`)}
                 fill="currentColor"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -179,7 +182,7 @@ export default function (props: FolderBlockProps) {
         </div>
       ))}
       <button
-        className="btn"
+        className={tw(`btn`)}
         style={{
           display: "flex",
           alignItems: "center",
@@ -202,7 +205,7 @@ export default function (props: FolderBlockProps) {
           width="1.3em"
           height="1.3em"
           viewBox="0 0 16 16"
-          className="bi bi-plus"
+          className={tw(`bi bi-plus`)}
           fill="currentColor"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/src/blocks/folder-blocks/infinite-canvas/BlockPicker.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/BlockPicker.tsx
@@ -1,4 +1,5 @@
 import { tw } from "twind";
+import { ActionList, ActionMenu } from "@primer/react";
 import { useState } from "react";
 import { Block } from "./index";
 
@@ -15,38 +16,27 @@ export const BlockPicker = ({
   const [iteration, setIteration] = useState(0);
 
   return (
-    <details
-      className={tw(
-        `dropdown details-reset details-overlay d-inline-block mr-2`
-      )}
-      key={iteration}
-    >
-      <summary className={tw(`btn`)} aria-haspopup="true">
-        {value?.title || "Block"}
-        <div className={tw(`dropdown-caret`)}></div>
-      </summary>
+    <ActionMenu>
+      <ActionMenu.Button>{value?.title || "Block"}</ActionMenu.Button>
 
-      <ul
-        className={tw(
-          `dropdown-menu dropdown-menu-sw max-h-[calc(100vh-16em)] overflow-auto`
-        )}
-      >
-        {options.map((block) => {
-          return (
-            <li key={block.key} className={tw(`dropdown-item text-sm`)}>
-              <button
-                onClick={() => {
+      <ActionMenu.Overlay>
+        <ActionList>
+          {options.map((block) => {
+            return (
+              <ActionList.Item
+                onSelect={() => {
                   onChange(block);
                   setIteration(iteration + 1);
                 }}
-                className={tw(`truncate w-full text-left`)}
+                key={block.key}
+                className={tw(`dropdown-item text-sm`)}
               >
                 {block.title}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-    </details>
+              </ActionList.Item>
+            );
+          })}
+        </ActionList>
+      </ActionMenu.Overlay>
+    </ActionMenu>
   );
 };

--- a/src/blocks/folder-blocks/infinite-canvas/BlockPicker.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/BlockPicker.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { useState } from "react";
 import { Block } from "./index";
 
@@ -15,24 +16,30 @@ export const BlockPicker = ({
 
   return (
     <details
-      className="dropdown details-reset details-overlay d-inline-block mr-2"
+      className={tw(
+        `dropdown details-reset details-overlay d-inline-block mr-2`
+      )}
       key={iteration}
     >
-      <summary className="btn" aria-haspopup="true">
+      <summary className={tw(`btn`)} aria-haspopup="true">
         {value?.title || "Block"}
-        <div className="dropdown-caret"></div>
+        <div className={tw(`dropdown-caret`)}></div>
       </summary>
 
-      <ul className="dropdown-menu dropdown-menu-sw max-h-[calc(100vh-16em)] overflow-auto">
+      <ul
+        className={tw(
+          `dropdown-menu dropdown-menu-sw max-h-[calc(100vh-16em)] overflow-auto`
+        )}
+      >
         {options.map((block) => {
           return (
-            <li key={block.key} className="dropdown-item text-sm">
+            <li key={block.key} className={tw(`dropdown-item text-sm`)}>
               <button
                 onClick={() => {
                   onChange(block);
                   setIteration(iteration + 1);
                 }}
-                className="truncate w-full text-left"
+                className={tw(`truncate w-full text-left`)}
               >
                 {block.title}
               </button>

--- a/src/blocks/folder-blocks/infinite-canvas/FilePicker.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/FilePicker.tsx
@@ -1,4 +1,6 @@
 import { tw } from "twind";
+import { ActionList, ActionMenu } from "@primer/react";
+
 import { useState } from "react";
 import { Files, File } from "./index";
 
@@ -13,36 +15,27 @@ export const FilePicker = ({
   const [iteration, setIteration] = useState(0);
 
   return (
-    <details
-      className={tw(`dropdown details-reset details-overlay d-inline-block`)}
-      key={iteration}
-    >
-      <summary className={tw(`btn`)} aria-haspopup="true">
-        + File
-        <div className={tw(`dropdown-caret`)}></div>
-      </summary>
+    <ActionMenu>
+      <ActionMenu.Button>+ File</ActionMenu.Button>
 
-      <ul
-        className={tw(
-          `dropdown-menu dropdown-menu-se w-full min-w-[16em] max-h-[calc(100vh-16em)] overflow-auto`
-        )}
-      >
-        {files.map((file) => {
-          return (
-            <li key={file.path} className={tw(`dropdown-item text-sm w-full`)}>
-              <button
-                onClick={() => {
+      <ActionMenu.Overlay>
+        <ActionList>
+          {files.map((file) => {
+            return (
+              <ActionList.Item
+                onSelect={() => {
                   onFileSelected(file);
                   setIteration(iteration + 1);
                 }}
-                className={tw(`truncate w-full text-left !overflow-hidden`)}
+                key={file.path}
+                className={tw(`dropdown-item text-sm w-full`)}
               >
                 {file.path}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-    </details>
+              </ActionList.Item>
+            );
+          })}
+        </ActionList>
+      </ActionMenu.Overlay>
+    </ActionMenu>
   );
 };

--- a/src/blocks/folder-blocks/infinite-canvas/FilePicker.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/FilePicker.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { useState } from "react";
 import { Files, File } from "./index";
 
@@ -13,24 +14,28 @@ export const FilePicker = ({
 
   return (
     <details
-      className="dropdown details-reset details-overlay d-inline-block"
+      className={tw(`dropdown details-reset details-overlay d-inline-block`)}
       key={iteration}
     >
-      <summary className="btn" aria-haspopup="true">
+      <summary className={tw(`btn`)} aria-haspopup="true">
         + File
-        <div className="dropdown-caret"></div>
+        <div className={tw(`dropdown-caret`)}></div>
       </summary>
 
-      <ul className="dropdown-menu dropdown-menu-se w-full min-w-[16em] max-h-[calc(100vh-16em)] overflow-auto">
+      <ul
+        className={tw(
+          `dropdown-menu dropdown-menu-se w-full min-w-[16em] max-h-[calc(100vh-16em)] overflow-auto`
+        )}
+      >
         {files.map((file) => {
           return (
-            <li key={file.path} className="dropdown-item text-sm w-full">
+            <li key={file.path} className={tw(`dropdown-item text-sm w-full`)}>
               <button
                 onClick={() => {
                   onFileSelected(file);
                   setIteration(iteration + 1);
                 }}
-                className="truncate w-full text-left !overflow-hidden"
+                className={tw(`truncate w-full text-left !overflow-hidden`)}
               >
                 {file.path}
               </button>

--- a/src/blocks/folder-blocks/infinite-canvas/Item.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/Item.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { useMemo, useRef, useState } from "react";
 import { useDrag } from "./useDrag";
 import { BlockPicker } from "./BlockPicker";
@@ -97,10 +98,12 @@ export const Item = ({
         ref={headerElement}
       />
 
-      <div className="px-3 py-2 w-full overflow-auto">
+      <div className={tw(`px-3 py-2 w-full overflow-auto`)}>
         {type === "text" ? (
           <div
-            className="Text focus:outline-none cursor-text w-full h-full text-sm"
+            className={tw(
+              `Text focus:outline-none cursor-text w-full h-full text-sm`
+            )}
             contentEditable
             suppressContentEditableWarning
             onInput={(e) => onChange({ text: e.target?.innerText || "" })}
@@ -111,14 +114,18 @@ export const Item = ({
             {textBuffer}
           </div>
         ) : type === "file" ? (
-          <div className="File h-full w-full flex flex-col">
-            <div className="flex-none flex items-center pb-1 w-full justify-between">
-              <div className="flex items-center pr-2 text-sm">
+          <div className={tw(`File h-full w-full flex flex-col`)}>
+            <div
+              className={tw(
+                `flex-none flex items-center pb-1 w-full justify-between`
+              )}
+            >
+              <div className={tw(`flex items-center pr-2 text-sm`)}>
                 <svg
                   viewBox="0 0 16 16"
                   width="16"
                   height="16"
-                  className="text-gray-500 fill-current mr-1"
+                  className={tw(`text-gray-500 fill-current mr-1`)}
                 >
                   <path d="M3.75 1.5a.25.25 0 00-.25.25v11.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V6H9.75A1.75 1.75 0 018 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0112.25 15h-8.5A1.75 1.75 0 012 13.25V1.75z"></path>
                 </svg>
@@ -133,8 +140,8 @@ export const Item = ({
               />
             </div>
             {BlockComponent && block ? (
-              <div className="w-full flex-1">
-                <div className="scaled-down">
+              <div className={tw(`w-full flex-1`)}>
+                <div className={tw(`scaled-down`)}>
                   <BlockComponent
                     {...(blockProps || {})}
                     block={block}
@@ -152,7 +159,11 @@ export const Item = ({
                 </div>
               </div>
             ) : (
-              <pre className="text-xs pl-[1.7em] overflow-auto py-1 text-gray-500">
+              <pre
+                className={tw(
+                  `text-xs pl-[1.7em] overflow-auto py-1 text-gray-500`
+                )}
+              >
                 {contents}
               </pre>
             )}
@@ -162,7 +173,9 @@ export const Item = ({
 
       {/* close button */}
       <button
-        className="position-absolute top-1 right-1 text-gray-500 opacity-0 group-hover:opacity-100"
+        className={tw(
+          `position-absolute top-1 right-1 text-gray-500 opacity-0 group-hover:opacity-100`
+        )}
         onClick={onDelete}
       >
         <svg viewBox="0 0 16 16" width="1em" height="1em" fill="currentColor">

--- a/src/blocks/folder-blocks/infinite-canvas/Item.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/Item.tsx
@@ -5,6 +5,7 @@ import { BlockPicker } from "./BlockPicker";
 import { ResizeButton } from "./ResizeButton";
 import pm from "picomatch";
 import { roundToInterval, Position, ItemType, Dimensions } from "./index";
+import { Box } from "@primer/react";
 
 export const Item = ({
   type,
@@ -81,8 +82,11 @@ export const Item = ({
   }[type];
 
   return (
-    <div
-      className={`item group Box shadow ${zIndex}`}
+    <Box
+      borderColor="border.default"
+      borderWidth={1}
+      borderStyle="solid"
+      className={`item group shadow ${zIndex}`}
       style={{
         width: dimensions[0],
         height: dimensions[1],
@@ -189,6 +193,6 @@ export const Item = ({
         }}
         dimensions={dimensions}
       />
-    </div>
+    </Box>
   );
 };

--- a/src/blocks/folder-blocks/infinite-canvas/Item.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/Item.tsx
@@ -174,7 +174,7 @@ export const Item = ({
       {/* close button */}
       <button
         className={tw(
-          `position-absolute top-1 right-1 text-gray-500 opacity-0 group-hover:opacity-100`
+          `absolute top-1 right-1 text-gray-500 opacity-0 group-hover:opacity-100`
         )}
         onClick={onDelete}
       >

--- a/src/blocks/folder-blocks/infinite-canvas/ResizeButton.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/ResizeButton.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { useRef } from "react";
 import { useDrag } from "./useDrag";
 import { Position } from "./index";
@@ -17,7 +18,9 @@ export const ResizeButton = ({
 
   return (
     <button
-      className="position-absolute bottom-0 right-0 w-5 h-5 bg-gray-200 z-10"
+      className={tw(
+        `position-absolute bottom-0 right-0 w-5 h-5 bg-gray-200 z-10`
+      )}
       style={{
         cursor: "nwse-resize",
       }}

--- a/src/blocks/folder-blocks/infinite-canvas/ResizeButton.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/ResizeButton.tsx
@@ -2,6 +2,7 @@ import { tw } from "twind";
 import { useRef } from "react";
 import { useDrag } from "./useDrag";
 import { Position } from "./index";
+import { Button } from "@primer/react";
 
 export const ResizeButton = ({
   onResize,
@@ -17,10 +18,8 @@ export const ResizeButton = ({
   });
 
   return (
-    <button
-      className={tw(
-        `position-absolute bottom-0 right-0 w-5 h-5 bg-gray-200 z-10`
-      )}
+    <Button
+      className={tw(`absolute bottom-0 right-0 w-5 h-5 bg-gray-200 z-10`)}
       style={{
         cursor: "nwse-resize",
       }}

--- a/src/blocks/folder-blocks/infinite-canvas/index.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/index.tsx
@@ -187,7 +187,7 @@ export default function (
         {/* our scrolling & panning listener */}
         <div
           className={tw(
-            `position-absolute top-[-50%] right-[-50%] bottom-[-50%] left-[-50%] pan`
+            `absolute top-[-50%] right-[-50%] bottom-[-50%] left-[-50%] pan`
           )}
           ref={wrapperElement}
           style={{

--- a/src/blocks/folder-blocks/infinite-canvas/index.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/index.tsx
@@ -7,6 +7,7 @@ import { useDrag } from "./useDrag";
 import { Item } from "./Item";
 import flatten from "lodash.flatten";
 import "./index.css";
+import { Button } from "@primer/react";
 
 const width = 5000;
 const height = 5000;
@@ -123,14 +124,9 @@ export default function (
   return (
     <div className={tw(`wrapper`)}>
       {/* add new item buttons */}
-      <div
-        className={tw(
-          `position-absolute top-2 left-2 z-10 flex flex-col space-y-2`
-        )}
-      >
+      <div className={tw(`absolute top-2 left-2 z-10 flex flex-col space-y-2`)}>
         {/* add text */}
-        <button
-          className={tw(`btn`)}
+        <Button
           onClick={() => {
             const newItems: ItemType[] = [
               ...items,
@@ -149,7 +145,7 @@ export default function (
           }}
         >
           + Add text
-        </button>
+        </Button>
 
         {/* add new file */}
         <FilePicker
@@ -237,8 +233,9 @@ export default function (
 
       {/* save button */}
       {isDirty && (
-        <button
-          className={tw(`btn btn-primary position-absolute top-2 right-2`)}
+        <Button
+          variant="primary"
+          className={tw(`absolute top-2 right-2`)}
           onClick={() => {
             onUpdateMetadata({
               items,
@@ -247,7 +244,7 @@ export default function (
           }}
         >
           Save changes
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/src/blocks/folder-blocks/infinite-canvas/index.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { FolderBlockProps, getNestedFileTree } from "@githubnext/utils";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Buffer } from "buffer";
@@ -120,12 +121,16 @@ export default function (
   }, []);
 
   return (
-    <div className="wrapper">
+    <div className={tw(`wrapper`)}>
       {/* add new item buttons */}
-      <div className="position-absolute top-2 left-2 z-10 flex flex-col space-y-2">
+      <div
+        className={tw(
+          `position-absolute top-2 left-2 z-10 flex flex-col space-y-2`
+        )}
+      >
         {/* add text */}
         <button
-          className="btn"
+          className={tw(`btn`)}
           onClick={() => {
             const newItems: ItemType[] = [
               ...items,
@@ -176,7 +181,7 @@ export default function (
 
       {/* our canvas! */}
       <div
-        className="canvas"
+        className={tw(`canvas`)}
         style={{
           width: width,
           height: height,
@@ -185,7 +190,9 @@ export default function (
       >
         {/* our scrolling & panning listener */}
         <div
-          className="position-absolute top-[-50%] right-[-50%] bottom-[-50%] left-[-50%] pan"
+          className={tw(
+            `position-absolute top-[-50%] right-[-50%] bottom-[-50%] left-[-50%] pan`
+          )}
           ref={wrapperElement}
           style={{
             cursor: isDragging ? "grabbing" : "grab",
@@ -231,7 +238,7 @@ export default function (
       {/* save button */}
       {isDirty && (
         <button
-          className="btn btn-primary position-absolute top-2 right-2"
+          className={tw(`btn btn-primary position-absolute top-2 right-2`)}
           onClick={() => {
             onUpdateMetadata({
               items,

--- a/src/blocks/folder-blocks/minimap/index.tsx
+++ b/src/blocks/folder-blocks/minimap/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 // @ts-ignore
-import { Tree } from "./Tree.jsx";
+import { Tree } from "./Tree";
 import { FolderBlockProps, getNestedFileTree } from "@githubnext/utils";
 
 export default function (props: FolderBlockProps) {

--- a/src/blocks/folder-blocks/overview/index.tsx
+++ b/src/blocks/folder-blocks/overview/index.tsx
@@ -1,3 +1,4 @@
+import { tw } from "twind";
 import { useCallback, useEffect, useState } from "react";
 import { FolderBlockProps } from "@githubnext/utils";
 import { Endpoints } from "@octokit/types";
@@ -69,18 +70,22 @@ export default function (props: FolderBlockProps) {
   }, []);
 
   return (
-    <div className="w-full">
-      <div className="p-3 flex-none">
+    <div className={tw(`w-full`)}>
+      <div className={tw(`p-3 flex-none`)}>
         {!isRoot ? null : !hasLoadedActivity ? (
-          <div className="px-3 py-10 w-full text-center color-fg-muted italic">
+          <div
+            className={tw(
+              `px-3 py-10 w-full text-center color-fg-muted italic`
+            )}
+          >
             Loading...
           </div>
         ) : (
-          <div className="flex w-full">
-            <div className="flex-1 p-2">
-              <h2 className="h2 px-3 py-1">Issues</h2>
+          <div className={tw(`flex w-full`)}>
+            <div className={tw(`flex-1 p-2`)}>
+              <h2 className={tw(`h2 px-3 py-1`)}>Issues</h2>
               {!issues.length && (
-                <div className="p-3 color-fg-muted italic">No issues</div>
+                <div className={tw(`p-3 color-fg-muted italic`)}>No issues</div>
               )}
               {issues.slice(0, maxItems).map((issue: IssueType) => (
                 <Issue issue={issue} />
@@ -88,16 +93,16 @@ export default function (props: FolderBlockProps) {
               {issues.length > maxItems && (
                 <a
                   href={`https://github.com/${context.owner}/${context.repo}/issues`}
-                  className="block px-3 py-2"
+                  className={tw(`block px-3 py-2`)}
                 >
                   + {issues.length - maxItems} more
                 </a>
               )}
             </div>
-            <div className="flex-1 p-2">
-              <h2 className="h2 px-3 py-1">PRs</h2>
+            <div className={tw(`flex-1 p-2`)}>
+              <h2 className={tw(`h2 px-3 py-1`)}>PRs</h2>
               {!pulls.length && (
-                <div className="p-3 color-fg-muted italic">
+                <div className={tw(`p-3 color-fg-muted italic`)}>
                   No open Pull Requests
                 </div>
               )}
@@ -107,7 +112,7 @@ export default function (props: FolderBlockProps) {
               {pulls.length > maxItems && (
                 <a
                   href={`https://github.com/${context.owner}/${context.repo}/pulls`}
-                  className="block px-3 py-2"
+                  className={tw(`block px-3 py-2`)}
                 >
                   + {pulls.length - maxItems} more
                 </a>
@@ -117,7 +122,7 @@ export default function (props: FolderBlockProps) {
         )}
       </div>
       {hasLoadedReadme && (
-        <div className="w-full">
+        <div className={tw(`w-full`)}>
           {!BlockComponent ? (
             "No BlockComponent"
           ) : doesHaveReadme ? (
@@ -126,7 +131,7 @@ export default function (props: FolderBlockProps) {
             // so we have to guess its height
             // thankfully, if it's taller, the main page will scroll, but we'd rather avoid that in most cases
             // because it feels funky to have two full-width scrolling elements
-            <div className="h-[150em]">
+            <div className={tw(`h-[150em]`)}>
               <BlockComponent
                 {...props}
                 block={readmeBlock}
@@ -148,14 +153,14 @@ export default function (props: FolderBlockProps) {
 
 const Issue = ({ issue }: { issue: IssueType }) => {
   return (
-    <div className="p-3">
-      <h4 className="h4">
-        <a href={issue.html_url} className="inline-block mr-1">
+    <div className={tw(`p-3`)}>
+      <h4 className={tw(`h4`)}>
+        <a href={issue.html_url} className={tw(`inline-block mr-1`)}>
           #{issue.number}
         </a>
         {issue.title}
       </h4>
-      <p className="mt-1 mb-1 f5 color-fg-muted">
+      <p className={tw(`mt-1 mb-1 f5 color-fg-muted`)}>
         <span className={`Label mr-1 Label--${issue.state} leading-none`}>
           {issue.state}
         </span>
@@ -163,20 +168,20 @@ const Issue = ({ issue }: { issue: IssueType }) => {
           {getRelativeTime(new Date(issue.updated_at))}
         </time>
       </p>
-      <p className="f5">{(issue.body || "").slice(0, 130)}</p>
+      <p className={tw(`f5`)}>{(issue.body || "").slice(0, 130)}</p>
     </div>
   );
 };
 const Pull = ({ pull }: { pull: PullType }) => {
   return (
-    <div className="p-3">
-      <h4 className="h4">
-        <a href={pull.html_url} className="inline-block mr-1">
+    <div className={tw(`p-3`)}>
+      <h4 className={tw(`h4`)}>
+        <a href={pull.html_url} className={tw(`inline-block mr-1`)}>
           #{pull.number}
         </a>
         {pull.title}
       </h4>
-      <p className="mt-1 mb-1 f5 color-fg-muted">
+      <p className={tw(`mt-1 mb-1 f5 color-fg-muted`)}>
         <span className={`Label mr-1 Label--${pull.state} leading-none`}>
           {pull.state}
         </span>
@@ -184,7 +189,7 @@ const Pull = ({ pull }: { pull: PullType }) => {
           {getRelativeTime(new Date(pull.updated_at))}
         </time>
       </p>
-      <p className="f5">{(pull.body || "").slice(0, 130)}</p>
+      <p className={tw(`f5`)}>{(pull.body || "").slice(0, 130)}</p>
     </div>
   );
 };

--- a/src/blocks/folder-blocks/overview/index.tsx
+++ b/src/blocks/folder-blocks/overview/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { FolderBlockProps } from "@githubnext/utils";
 import { Endpoints } from "@octokit/types";
 import { getRelativeTime } from "./utils";
+import { Heading, Link, Text, Label } from "@primer/react";
 
 // Note: We're using a BlockComponent prop here to create nested Blocks.
 // This is only implemented for our own example Blocks, to showcase the concept.
@@ -73,19 +74,23 @@ export default function (props: FolderBlockProps) {
     <div className={tw(`w-full`)}>
       <div className={tw(`p-3 flex-none`)}>
         {!isRoot ? null : !hasLoadedActivity ? (
-          <div
-            className={tw(
-              `px-3 py-10 w-full text-center color-fg-muted italic`
-            )}
-          >
-            Loading...
+          <div className={tw(`px-3 py-10 w-full text-center`)}>
+            <Text color="fg.muted" sx={{ fontStyle: "italic" }}>
+              Loading...
+            </Text>
           </div>
         ) : (
           <div className={tw(`flex w-full`)}>
             <div className={tw(`flex-1 p-2`)}>
-              <h2 className={tw(`h2 px-3 py-1`)}>Issues</h2>
+              <Heading sx={{ fontSize: 4 }} className={tw(`px-3 py-1`)}>
+                Issues
+              </Heading>
               {!issues.length && (
-                <div className={tw(`p-3 color-fg-muted italic`)}>No issues</div>
+                <div className={tw(`p-3`)}>
+                  <Text color="fg.muted" sx={{ fontStyle: "italic" }}>
+                    No issues
+                  </Text>
+                </div>
               )}
               {issues.slice(0, maxItems).map((issue: IssueType) => (
                 <Issue issue={issue} />
@@ -100,10 +105,14 @@ export default function (props: FolderBlockProps) {
               )}
             </div>
             <div className={tw(`flex-1 p-2`)}>
-              <h2 className={tw(`h2 px-3 py-1`)}>PRs</h2>
+              <Heading sx={{ fontSize: 4 }} className={tw(`px-3 py-1`)}>
+                PRs
+              </Heading>
               {!pulls.length && (
-                <div className={tw(`p-3 color-fg-muted italic`)}>
-                  No open Pull Requests
+                <div className={tw(`p-3`)}>
+                  <Text color="fg.muted" sx={{ fontStyle: "italic" }}>
+                    No open Pull Requests
+                  </Text>
                 </div>
               )}
               {pulls.slice(0, maxItems).map((pull: PullType) => (
@@ -154,42 +163,63 @@ export default function (props: FolderBlockProps) {
 const Issue = ({ issue }: { issue: IssueType }) => {
   return (
     <div className={tw(`p-3`)}>
-      <h4 className={tw(`h4`)}>
-        <a href={issue.html_url} className={tw(`inline-block mr-1`)}>
+      <Heading as="h4" sx={{ fontSize: 2, mb: 2 }}>
+        <Link href={issue.html_url} className={tw(`mr-1`)}>
           #{issue.number}
-        </a>
+        </Link>
         {issue.title}
-      </h4>
-      <p className={tw(`mt-1 mb-1 f5 color-fg-muted`)}>
-        <span className={`Label mr-1 Label--${issue.state} leading-none`}>
+      </Heading>
+      <p className={tw(`mt-1 mb-1 f5`)}>
+        <Label
+          variant={issue.state === "open" ? "success" : "danger"}
+          className={`mr-1`}
+        >
           {issue.state}
-        </span>
-        <time dateTime={issue.updated_at}>
+        </Label>
+        <Text
+          sx={{ fontSize: 1 }}
+          color="fg.muted"
+          as="time"
+          dateTime={issue.updated_at}
+        >
           {getRelativeTime(new Date(issue.updated_at))}
-        </time>
+        </Text>
       </p>
-      <p className={tw(`f5`)}>{(issue.body || "").slice(0, 130)}</p>
+      <Text color="fg.muted" as="p">
+        {(issue.body || "").slice(0, 130)}
+      </Text>
     </div>
   );
 };
 const Pull = ({ pull }: { pull: PullType }) => {
   return (
     <div className={tw(`p-3`)}>
-      <h4 className={tw(`h4`)}>
-        <a href={pull.html_url} className={tw(`inline-block mr-1`)}>
+      <Heading as="h1" sx={{ fontSize: 2, mb: 2 }}>
+        <Link href={pull.html_url} className={tw(`mr-1`)}>
           #{pull.number}
-        </a>
+        </Link>
         {pull.title}
-      </h4>
+      </Heading>
+
       <p className={tw(`mt-1 mb-1 f5 color-fg-muted`)}>
-        <span className={`Label mr-1 Label--${pull.state} leading-none`}>
+        <Label
+          variant={pull.state === "open" ? "success" : "danger"}
+          className={`mr-1`}
+        >
           {pull.state}
-        </span>
-        <time dateTime={pull.updated_at}>
+        </Label>
+        <Text
+          sx={{ fontSize: 1 }}
+          color="fg.muted"
+          as="time"
+          dateTime={pull.updated_at}
+        >
           {getRelativeTime(new Date(pull.updated_at))}
-        </time>
+        </Text>
       </p>
-      <p className={tw(`f5`)}>{(pull.body || "").slice(0, 130)}</p>
+      <Text color="fg.muted" as="p">
+        {(pull.body || "").slice(0, 130)}
+      </Text>
     </div>
   );
 };

--- a/src/blocks/folder-blocks/overview/index.tsx
+++ b/src/blocks/folder-blocks/overview/index.tsx
@@ -163,7 +163,7 @@ export default function (props: FolderBlockProps) {
 const Issue = ({ issue }: { issue: IssueType }) => {
   return (
     <div className={tw(`p-3`)}>
-      <Heading as="h4" sx={{ fontSize: 2, mb: 2 }}>
+      <Heading as="h3" sx={{ fontSize: 2, mb: 2 }}>
         <Link href={issue.html_url} className={tw(`mr-1`)}>
           #{issue.number}
         </Link>
@@ -187,6 +187,7 @@ const Issue = ({ issue }: { issue: IssueType }) => {
       </p>
       <Text color="fg.muted" as="p">
         {(issue.body || "").slice(0, 130)}
+        {issue?.body?.length && issue.body.length > 130 ? "..." : ""}
       </Text>
     </div>
   );
@@ -194,7 +195,7 @@ const Issue = ({ issue }: { issue: IssueType }) => {
 const Pull = ({ pull }: { pull: PullType }) => {
   return (
     <div className={tw(`p-3`)}>
-      <Heading as="h1" sx={{ fontSize: 2, mb: 2 }}>
+      <Heading as="h3" sx={{ fontSize: 2, mb: 2 }}>
         <Link href={pull.html_url} className={tw(`mr-1`)}>
           #{pull.number}
         </Link>
@@ -219,6 +220,7 @@ const Pull = ({ pull }: { pull: PullType }) => {
       </p>
       <Text color="fg.muted" as="p">
         {(pull.body || "").slice(0, 130)}
+        {pull?.body?.length && pull.body.length > 130 ? "..." : ""}
       </Text>
     </div>
   );

--- a/src/components/local-block.tsx
+++ b/src/components/local-block.tsx
@@ -7,6 +7,7 @@ import {
   RepoFiles,
   onRequestGitHubData as onRequestGitHubDataFetch,
 } from "@githubnext/utils";
+import { ThemeProvider } from "@primer/react";
 
 interface Block {
   id: string;
@@ -96,17 +97,19 @@ export const LocalBlock = (props: LocalBlockProps) => {
 
   if (!Block) return null;
   return (
-    <Block
-      context={context}
-      content={content}
-      originalContent={originalContent}
-      isEditable={true}
-      tree={tree}
-      metadata={metadata}
-      onUpdateMetadata={onUpdateMetadata}
-      onNavigateToPath={onNavigateToPath}
-      onUpdateContent={setContent}
-      onRequestGitHubData={onRequestGitHubData}
-    />
+    <ThemeProvider>
+      <Block
+        context={context}
+        content={content}
+        originalContent={originalContent}
+        isEditable={true}
+        tree={tree}
+        metadata={metadata}
+        onUpdateMetadata={onUpdateMetadata}
+        onNavigateToPath={onNavigateToPath}
+        onUpdateContent={setContent}
+        onRequestGitHubData={onRequestGitHubData}
+      />
+    </ThemeProvider>
   );
 };

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -162,11 +162,7 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
       <SandpackProvider
         template="react"
         customSetup={{
-          dependencies: {
-            "@primer/react": "^35.2.0",
-            // https://github.com/primer/react/blob/main/package.json#L188
-            "styled-components": "4.x",
-          },
+          dependencies: {},
           files,
         }}
         autorun

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -1,5 +1,5 @@
 import { SandpackProvider, SandpackPreview } from "@codesandbox/sandpack-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 // @ts-ignore
 import {
   FileContext,
@@ -162,7 +162,10 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
       <SandpackProvider
         template="react"
         customSetup={{
-          dependencies: {},
+          dependencies: {
+            "styled-components": "^5.3.3",
+            "@primer/react": "^35.2.0",
+          },
           files,
         }}
         autorun

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -162,7 +162,11 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
       <SandpackProvider
         template="react"
         customSetup={{
-          dependencies: {},
+          dependencies: {
+            "@primer/react": "^35.2.0",
+            // https://github.com/primer/react/blob/main/package.json#L188
+            "styled-components": "4.x",
+          },
           files,
         }}
         autorun

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -160,7 +160,6 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
       }}
     >
       <SandpackProvider
-        externalResources={["https://cdn.tailwindcss.com"]}
         template="react"
         customSetup={{
           dependencies: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,18 +655,18 @@
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
-"@codesandbox/sandpack-client@^0.13.15":
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-0.13.15.tgz#b429c56b300e929d9e2a5c56b6108e7615e6ce1f"
-  integrity sha512-v2p/eYUZ2iWf0PnKUvklp4DytgucdYgUWHZlK23mG3FvPt49nysy3LzoB4igSg6pD7Xegmi3p6L46J7LeYJIZw==
+"@codesandbox/sandpack-client@^0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-0.19.1.tgz#5ccfd37c9b37b483f3636fa5ed3a7f153752f7c6"
+  integrity sha512-qXzp6HkoXVubl0/z9+65T8O1zjWU4BjxRvr6uyl9IACKZPMr8QGXfULdLNzJZBbHzo7mJcVwEYDO2Gzz375EZw==
   dependencies:
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@^0.13.13":
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.15.tgz#9178d2b77e1e8c03a97c9532ca4ccfb684cb9b1d"
-  integrity sha512-AaUcjbADFC0cTMev15Et/Frc+yQ+tV4jdoxULrRW2XT2g6h7nihUR/cryXOSC/HDfipWOfELPOmXyvmQAJMxWA==
+"@codesandbox/sandpack-react@^0.19.3":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.19.3.tgz#81ab6101d0aa15013ac3129949e4cbc195c68a36"
+  integrity sha512-6ApE79iSGzJvnLgk4uY9+vJxWJ87U2RynpGFD+ogODrcEHIuYdeZnXVXP1tokI28hEMb8fGBieDwRLoFwm9/CA==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"
@@ -682,11 +682,11 @@
     "@codemirror/matchbrackets" "^0.19.3"
     "@codemirror/state" "^0.19.6"
     "@codemirror/view" "^0.19.32"
-    "@codesandbox/sandpack-client" "^0.13.15"
+    "@codesandbox/sandpack-client" "^0.19.1"
     "@react-hook/intersection-observer" "^3.1.1"
     codesandbox-import-util-types "^2.2.3"
-    codesandbox-import-utils "^2.2.3"
     lodash.isequal "^4.5.0"
+    lz-string "^1.4.4"
     react-devtools-inline "4.4.0"
     react-is "^17.0.2"
 
@@ -2656,7 +2656,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-binaryextensions@2, binaryextensions@^2.1.2:
+binaryextensions@2:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.3.0.tgz#1d269cbf7e6243ea886aa41453c3651ccbe13c22"
   integrity sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==
@@ -2975,15 +2975,6 @@ codesandbox-import-utils@^1.2.3:
   dependencies:
     codesandbox-import-util-types "^1.3.7"
     istextorbinary "2.2.1"
-    lz-string "^1.4.4"
-
-codesandbox-import-utils@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/codesandbox-import-utils/-/codesandbox-import-utils-2.2.3.tgz#f7b4801245b381cb8c90fe245e336624e19b6c84"
-  integrity sha512-ymtmcgZKU27U+nM2qUb21aO8Ut/u2S9s6KorOgG81weP+NA0UZkaHKlaRqbLJ9h4i/4FLvwmEXYAnTjNmp6ogg==
-  dependencies:
-    codesandbox-import-util-types "^2.2.3"
-    istextorbinary "^2.2.1"
     lz-string "^1.4.4"
 
 color-convert@^1.9.0, color-convert@^1.9.3:
@@ -3997,14 +3988,6 @@ editions@^1.3.3:
   resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
   integrity sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==
 
-editions@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/editions/-/editions-2.3.1.tgz#3bc9962f1978e801312fbd0aebfed63b49bfe698"
-  integrity sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==
-  dependencies:
-    errlop "^2.0.0"
-    semver "^6.3.0"
-
 electron-to-chromium@^1.4.84:
   version "1.4.103"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz#abfe376a4d70fa1e1b4b353b95df5d6dfd05da3a"
@@ -4038,11 +4021,6 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
-
-errlop@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/errlop/-/errlop-2.2.0.tgz#1ff383f8f917ae328bebb802d6ca69666a42d21b"
-  integrity sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
@@ -5374,15 +5352,6 @@ istextorbinary@2.2.1:
     binaryextensions "2"
     editions "^1.3.3"
     textextensions "2"
-
-istextorbinary@^2.2.1:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-2.6.0.tgz#60776315fb0fa3999add276c02c69557b9ca28ab"
-  integrity sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==
-  dependencies:
-    binaryextensions "^2.1.2"
-    editions "^2.2.0"
-    textextensions "^2.5.0"
 
 js-base64@^3.7.2:
   version "3.7.2"
@@ -7757,7 +7726,7 @@ tailwindcss@^2.2.7:
     resolve "^1.20.0"
     tmp "^0.2.1"
 
-textextensions@2, textextensions@^2.5.0:
+textextensions@2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.6.0.tgz#d7e4ab13fe54e32e08873be40d51b74229b00fc4"
   integrity sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,29 +1171,6 @@
   resolved "https://registry.yarnpkg.com/@primer/behaviors/-/behaviors-1.1.1.tgz#51e2f02ebfe297c4c05f503cdc52ae8b4ce5794c"
   integrity sha512-wvF1PYjyxKNTr6+5w4uR5Gkz53t1fsRDgKjWxDKk7wmlh0cwiILBo4dDFjjVhWRF1mBSjaIxxJGB4WGaP7ct2Q==
 
-"@primer/components@^31.1.0":
-  version "31.2.0"
-  resolved "https://registry.yarnpkg.com/@primer/components/-/components-31.2.0.tgz#6a421bd252f8b2e35b888a22ea77779dc6895762"
-  integrity sha512-4ICaA+Fp0JdGAisKiIYYeo2gfqu5tZpF0y4S9kRdc0U72YZ/MVBpZee5xYDfcVig5MV3Dh3Lfo48KWWMQIyd+g==
-  dependencies:
-    "@primer/octicons-react" "^16.1.0"
-    "@primer/primitives" "6.1.0"
-    "@radix-ui/react-polymorphic" "0.0.14"
-    "@react-aria/ssr" "3.1.0"
-    "@styled-system/css" "5.1.5"
-    "@styled-system/props" "5.1.5"
-    "@styled-system/theme-get" "5.1.2"
-    "@types/history" "4.7.8"
-    "@types/styled-components" "5.1.11"
-    "@types/styled-system" "5.1.12"
-    "@types/styled-system__css" "5.0.16"
-    "@types/styled-system__theme-get" "5.0.1"
-    classnames "2.3.1"
-    color2k "1.2.4"
-    deepmerge "4.2.2"
-    focus-visible "5.2.0"
-    styled-system "5.1.5"
-
 "@primer/octicons-react@16.1.1":
   version "16.1.1"
   resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-16.1.1.tgz#6a9eaffbbf46cb44d344a37a5ff2384973b82d3f"
@@ -1204,15 +1181,10 @@
   resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-12.1.0.tgz#7556450199e0c10e72e99dd02c59f1ac33544767"
   integrity sha512-eb/5Obsp6/pVkyzzGhobK6aPAkKqx6VleF/7HYeihGTYm3rGZc+prL/jhxD5Mo1P6U343YEkHjc2gKuvtENn1g==
 
-"@primer/octicons-react@^16.0.0", "@primer/octicons-react@^16.1.0":
+"@primer/octicons-react@^16.0.0":
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-16.3.1.tgz#86982fe1001eee138d5ee46accbcdf62d51d11c5"
   integrity sha512-uzTs8/CvLiW1/47cgMRkIK9bKWpnw+UonCbgczXErwSSLqMDHfiiTpobW1trvRuoiMgLwsPo0l7kBBdKBnmq3g==
-
-"@primer/primitives@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-6.1.0.tgz#9fe385913b922b4e48cac19fe5e560e4ae9e284d"
-  integrity sha512-gwSVf5rVf2CMa/bU3/47LZosDHNfODMRJfKi7uJOqHWABVNl6Lf+thDM7Jb8tS9sEQQsUnrLDiGNjCScS81IXA==
 
 "@primer/primitives@7.6.0":
   version "7.6.0"
@@ -2089,11 +2061,6 @@
   integrity sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==
   dependencies:
     "@types/unist" "*"
-
-"@types/history@4.7.8":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
-  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
 
 "@types/hoist-non-react-statics@*":
   version "3.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,10 +816,10 @@
     unist-util-visit "^1.0.0"
     uuid "^3.3.2"
 
-"@githubnext/utils@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.21.0.tgz#d564718803e68e53258382766212585831bb48fa"
-  integrity sha512-gRRasLrE3l4R7J73wdMlVko6N+/rh1GjCm5wPlaSaUkcAL8corlBz1mJQ7TyvD9/LJMUy1X9X7pnqNEjVZsHyA==
+"@githubnext/utils@^0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.22.0.tgz#70fba0ca4ddb5dc5979d7e5711da0581674f2461"
+  integrity sha512-F/ay94PL8c/gK8ks7CkQGYDwiUJo5h+ccnbfzzBovT/MudkIseSut8qkP+br7JT0lBrmAmMQAzTsQaMcz2j2pg==
   dependencies:
     "@types/lodash.uniqueid" "^4.0.6"
     lodash.uniqueid "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,7 +3281,7 @@ cssjson@^2.1.3:
   resolved "https://registry.yarnpkg.com/cssjson/-/cssjson-2.1.3.tgz#b855aa06c5979df16bf6375a14a455e415660169"
   integrity sha1-uFWqBsWXnfFr9jdaFKRV5BVmAWk=
 
-csstype@^3.0.2, csstype@^3.0.4, csstype@^3.0.6:
+csstype@^3.0.2, csstype@^3.0.4, csstype@^3.0.5, csstype@^3.0.6:
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
   integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
@@ -3952,10 +3952,40 @@ dom-helpers@^5.0.1:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
 
+dom-serializer@^1.0.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
+  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
+  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
+  dependencies:
+    domelementtype "^2.2.0"
+
 dompurify@^2.2.9, dompurify@^2.3.3:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.6.tgz#2e019d7d7617aacac07cbbe3d88ae3ad354cf875"
   integrity sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg==
+
+domutils@^2.5.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 dot-prop@^5.2.0:
   version "5.3.0"
@@ -4036,6 +4066,11 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 errlop@^2.0.0:
   version "2.2.0"
@@ -4908,6 +4943,16 @@ html-tags@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
+
+htmlparser2@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 http-cache-semantics@^4.0.0:
   version "4.1.0"
@@ -7594,6 +7639,11 @@ style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
+style-vendorizer@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/style-vendorizer/-/style-vendorizer-2.1.1.tgz#5f06601c1724cfb314fe1153e7e442c58dde771c"
+  integrity sha512-gVO6Cwxtg8iX0X1W4xMhSc5WbQpiIBQDkhq3JkwebMRRgyhCfuvMrnPlTAGTRjfQPGRmzgjCOZ4drehTnLahHA==
+
 styled-components@^3.1.6:
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.10.tgz#9a654c50ea2b516c36ade57ddcfa296bf85c96e1"
@@ -7913,6 +7963,15 @@ twin.macro@^2.6.2:
     string-similarity "^4.0.3"
     tailwindcss "^2.2.7"
     timsort "^0.3.0"
+
+twind@^0.16.17:
+  version "0.16.17"
+  resolved "https://registry.yarnpkg.com/twind/-/twind-0.16.17.tgz#ca8434d7570cd4246ea2f9d6269aa597e00730aa"
+  integrity sha512-dBKm8+ncJcIALiqBRLxA/krFEwUSjnzR+N73eKgqPtVPJqfLpkajWwKWL5xEpEQ5ypS3ffa0jJjH3/eIeuA3pw==
+  dependencies:
+    csstype "^3.0.5"
+    htmlparser2 "^6.0.0"
+    style-vendorizer "^2.0.0"
 
 type-fest@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
Removes our global addition of Tailwind CSS (via CDN). Moving forward, Tailwind classes can be used by including the `twind` library and using the following syntax.

```tsx
className={tw(`bg-red-200 p-4`)}
```

**Notes**
- I had to bump our version of Sandpack to `latest` due to an issue with `@primer/react`. See https://github.com/primer/react/issues/1863 and https://github.com/codesandbox/codesandbox-client/issues/6473