### PR TITLE
update example blocks for new props

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
     "@excalidraw/excalidraw": "^0.10.0",
     "@fullstackio/cq": "^6.0.9",
     "@fullstackio/remark-cq": "^6.1.2",
-    "@githubnext/utils": "^0.19.7",
+    "@githubnext/utils": "^0.20.0",
     "@githubocto/flat-ui": "^0.13.4",
     "@loadable/component": "^5.15.0",
     "@mdx-js/runtime": "2.0.0-next.9",

--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
     "@excalidraw/excalidraw": "^0.10.0",
     "@fullstackio/cq": "^6.0.9",
     "@fullstackio/remark-cq": "^6.1.2",
-    "@githubnext/utils": "^0.20.0",
+    "@githubnext/utils": "^0.21.0",
     "@githubocto/flat-ui": "^0.13.4",
     "@loadable/component": "^5.15.0",
     "@mdx-js/runtime": "2.0.0-next.9",

--- a/src/blocks/file-blocks/code/index.tsx
+++ b/src/blocks/file-blocks/code/index.tsx
@@ -79,15 +79,15 @@ export default function (props: FileBlockProps) {
   const {
     content,
     context: { path },
-    onRequestUpdateContent,
+    isEditable,
+    onUpdateContent,
   } = props;
 
   const editorRef = React.useRef<HTMLDivElement>(null);
 
-  // track `onRequestUpdateContent` so the `updateListener` callback gets the latest one.
-  const onRequestUpdateContentRef =
-    React.useRef<typeof onRequestUpdateContent>();
-  onRequestUpdateContentRef.current = onRequestUpdateContent;
+  // track `onUpdateContent` so the `updateListener` callback gets the latest one.
+  const onUpdateContentRef = React.useRef<typeof onUpdateContent>();
+  onUpdateContentRef.current = onUpdateContent;
 
   const viewRef = React.useRef<EditorView>();
 
@@ -108,10 +108,11 @@ export default function (props: FileBlockProps) {
       doc: content,
       extensions: [
         extensions,
+        EditorView.editable.of(isEditable),
         EditorView.updateListener.of((v) => {
           if (!v.docChanged) return;
-          if (!onRequestUpdateContentRef.current) return;
-          onRequestUpdateContentRef.current(v.state.doc.sliceString(0));
+          if (!onUpdateContentRef.current) return;
+          onUpdateContentRef.current(v.state.doc.sliceString(0));
         }),
       ],
     });

--- a/src/blocks/file-blocks/code/index.tsx
+++ b/src/blocks/file-blocks/code/index.tsx
@@ -84,11 +84,6 @@ export default function (props: FileBlockProps) {
   } = props;
 
   const editorRef = React.useRef<HTMLDivElement>(null);
-
-  // track `onUpdateContent` so the `updateListener` callback gets the latest one.
-  const onUpdateContentRef = React.useRef<typeof onUpdateContent>();
-  onUpdateContentRef.current = onUpdateContent;
-
   const viewRef = React.useRef<EditorView>();
 
   if (viewRef.current) {
@@ -111,8 +106,7 @@ export default function (props: FileBlockProps) {
         EditorView.editable.of(isEditable),
         EditorView.updateListener.of((v) => {
           if (!v.docChanged) return;
-          if (!onUpdateContentRef.current) return;
-          onUpdateContentRef.current(v.state.doc.sliceString(0));
+          onUpdateContent(v.state.doc.sliceString(0));
         }),
       ],
     });

--- a/src/blocks/file-blocks/edit/index.tsx
+++ b/src/blocks/file-blocks/edit/index.tsx
@@ -9,7 +9,7 @@ import { diffAsText } from "unidiff";
 import "./index.css";
 
 export default function (props: FileBlockProps) {
-  const { content, context, onRequestUpdateContent } = props;
+  const { content, context, onUpdateContent } = props;
 
   const [instruction, setInstruction] = useState<string>("");
   const [newContent, setNewContent] = useState<string>("");
@@ -80,7 +80,7 @@ export default function (props: FileBlockProps) {
             <button
               className="btn btn-primary"
               onClick={() => {
-                onRequestUpdateContent(newContent);
+                onUpdateContent(newContent);
               }}
             >
               Save changes

--- a/src/blocks/file-blocks/excalidraw/index.tsx
+++ b/src/blocks/file-blocks/excalidraw/index.tsx
@@ -13,7 +13,7 @@ if (typeof window !== "undefined") {
   }
 }
 export default function (props: FileBlockProps) {
-  const { context, content, onRequestUpdateContent } = props;
+  const { context, content, isEditable, onUpdateContent } = props;
   const [excalModule, setExcalModule] = useState<any>(null);
 
   useEffect(() => {
@@ -28,7 +28,7 @@ export default function (props: FileBlockProps) {
       return;
     }
     const serialized = excalModule.serializeAsJSON(elements, appState);
-    onRequestUpdateContent(serialized);
+    onUpdateContent(serialized);
   };
 
   const ExcalidrawComponent = excalModule ? excalModule.default : null;
@@ -37,6 +37,7 @@ export default function (props: FileBlockProps) {
     <div className="width-full" key={context.path} style={{ height: "100vh" }}>
       {ExcalidrawComponent && (
         <ExcalidrawComponent
+          viewModeEnabled={!isEditable}
           initialData={JSON.parse(content)}
           onChange={handleChange}
         />

--- a/src/blocks/file-blocks/flat.tsx
+++ b/src/blocks/file-blocks/flat.tsx
@@ -1,36 +1,42 @@
 import { FileBlockProps } from "@githubnext/utils";
 import { Grid } from "@githubocto/flat-ui";
 import { csvFormat, csvParseRows } from "d3";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
+
+function parseCSV(content: string) {
+  try {
+    const rows = csvParseRows(content);
+    const headers = rows[0];
+    const csvData = rows.slice(1).map((row: any) => {
+      return headers.reduce((acc: Record<string, any>, key, i) => {
+        acc[key] = Number.isFinite(row[i]) ? +row[i] : row[i];
+        return acc;
+      }, {});
+    });
+    return csvData;
+  } catch (e) {
+    return [];
+  }
+}
 
 export default function (props: FileBlockProps) {
-  const { content, onRequestUpdateContent } = props;
+  const { content, originalContent, isEditable, onUpdateContent } = props;
 
-  const data = useMemo(() => {
-    try {
-      const rows = csvParseRows(content);
-      const headers = rows[0];
-      const csvData = rows.slice(1).map((row: any) => {
-        return headers.reduce((acc: Record<string, any>, key, i) => {
-          acc[key] = Number.isFinite(row[i]) ? +row[i] : row[i];
-          return acc;
-        }, {});
-      });
-      return csvData;
-    } catch (e) {
-      return [];
-    }
-  }, [content]);
+  const data = useMemo(() => parseCSV(content), [content]);
+  const originalData = useMemo(
+    () => parseCSV(originalContent),
+    [originalContent]
+  );
 
   return (
     <div className="height-full d-flex flex-column flex-1">
       <Grid
         data={data}
-        diffData={data}
+        diffData={originalData}
         canDownload={false}
-        isEditable
+        isEditable={isEditable}
         onEdit={(data: any) => {
-          onRequestUpdateContent(csvFormat(data));
+          onUpdateContent(csvFormat(data));
         }}
       />
     </div>

--- a/src/blocks/file-blocks/geojson.tsx
+++ b/src/blocks/file-blocks/geojson.tsx
@@ -14,7 +14,7 @@ import { Geometry } from "ol/geom";
 import "ol/ol.css";
 
 export default function (props: FileBlockProps) {
-  const { content, onRequestUpdateContent } = props;
+  const { content, isEditable, onUpdateContent } = props;
 
   const [hoveredFeatureId, setHoveredFeatureId] =
     useState<Feature<Geometry> | null>(null);
@@ -185,7 +185,7 @@ export default function (props: FileBlockProps) {
                         className="flex-1 text-xs text-gray-900 font-mono max-w-[20em] truncate min-w-[10em]"
                         title={currentValue}
                       >
-                        {typeof currentValue === "string" ? (
+                        {isEditable && typeof currentValue === "string" ? (
                           <EditableText
                             value={currentValue}
                             onChange={(value) => {
@@ -223,9 +223,7 @@ export default function (props: FileBlockProps) {
                                   [key]: value,
                                 };
                               }
-                              onRequestUpdateContent(
-                                JSON.stringify(newGeojson)
-                              );
+                              onUpdateContent(JSON.stringify(newGeojson));
                             }}
                           />
                         ) : (

--- a/src/blocks/file-blocks/json.tsx
+++ b/src/blocks/file-blocks/json.tsx
@@ -1,19 +1,20 @@
 import { FileBlockProps } from "@githubnext/utils";
 import { useMemo } from "react";
 import ReactJson from "react-json-view";
+import type { InteractionProps } from "react-json-view";
 import jsYaml from "js-yaml";
 
 export default function (props: FileBlockProps) {
-  const { content, context, onRequestUpdateContent } = props;
+  const { content, context, isEditable, onUpdateContent } = props;
 
   const extension = context.path.split(".").pop() || "";
   const isYaml = ["yaml", "yml"].includes(extension);
 
-  const setModifiedContent = (data: string) => {
+  const setModifiedContent = (data: unknown) => {
     const contentString = isYaml
       ? jsYaml.dump(data)
       : JSON.stringify(data, null, 2);
-    onRequestUpdateContent(contentString);
+    onUpdateContent(contentString);
   };
 
   const data = useMemo(() => {
@@ -28,6 +29,10 @@ export default function (props: FileBlockProps) {
       return null;
     }
   }, [content]);
+
+  const onChange = isEditable
+    ? (e: InteractionProps) => setModifiedContent(e.updated_src)
+    : undefined;
 
   return (
     <div
@@ -61,18 +66,9 @@ export default function (props: FileBlockProps) {
               backgroundColor: "transparent",
               color: "#333",
             }}
-            onEdit={(e) => {
-              // @ts-ignore
-              setModifiedContent(e.updated_src);
-            }}
-            onAdd={(e) => {
-              // @ts-ignore
-              setModifiedContent(e.updated_src);
-            }}
-            onDelete={(e) => {
-              // @ts-ignore
-              setModifiedContent(e.updated_src);
-            }}
+            onEdit={onChange}
+            onAdd={onChange}
+            onDelete={onChange}
           />
         </>
       ) : (

--- a/src/blocks/file-blocks/poll.tsx
+++ b/src/blocks/file-blocks/poll.tsx
@@ -18,18 +18,12 @@ export default function (props: FileBlockProps) {
   const { content, isEditable, onUpdateContent } = props;
   const poll = JSON.parse(content);
 
-  const onVote = (index: number) => {
+  const onClick = (index: number) => {
+    if (!isEditable) return;
     const newPoll = { ...poll };
     newPoll.options[index].votes += 1;
     onUpdateContent(JSON.stringify(newPoll));
   };
-
-  const onClick = (index: number) =>
-    isEditable
-      ? () => {
-          onVote(index);
-        }
-      : () => {};
 
   if (!poll || !poll.options)
     return (

--- a/src/blocks/file-blocks/poll.tsx
+++ b/src/blocks/file-blocks/poll.tsx
@@ -15,14 +15,21 @@ type Poll = {
 };
 
 export default function (props: FileBlockProps) {
-  const { content } = props;
+  const { content, isEditable, onUpdateContent } = props;
   const poll = JSON.parse(content);
 
   const onVote = (index: number) => {
     const newPoll = { ...poll };
     newPoll.options[index].votes += 1;
-    props.onRequestUpdateContent(JSON.stringify(newPoll));
+    onUpdateContent(JSON.stringify(newPoll));
   };
+
+  const onClick = (index: number) =>
+    isEditable
+      ? () => {
+          onVote(index);
+        }
+      : () => {};
 
   if (!poll || !poll.options)
     return (
@@ -51,10 +58,12 @@ export default function (props: FileBlockProps) {
               <span className="mr-2">{percent}%</span>
               <span className="font-light mr-2">{option.votes} votes</span>
               <button
-                className="bg-transparent hover:bg-blue-500 text-blue-400 hover:text-white px-2 border border-blue-500 hover:border-transparent rounded"
-                onClick={() => {
-                  onVote(index);
-                }}
+                disabled={!isEditable}
+                className={
+                  "bg-transparent hover:bg-blue-500 text-blue-400 hover:text-white px-2 border border-blue-500 hover:border-transparent rounded" +
+                  (!isEditable ? " pointer-events-none" : "")
+                }
+                onClick={onClick(index)}
               >
                 Vote
               </button>

--- a/src/components/local-block.tsx
+++ b/src/components/local-block.tsx
@@ -104,7 +104,6 @@ export const LocalBlock = (props: LocalBlockProps) => {
       onUpdateMetadata={onUpdateMetadata}
       onNavigateToPath={onNavigateToPath}
       onUpdateContent={setContent}
-      onRequestUpdateContent={setContent} // for backward compatibility
       onRequestGitHubData={onRequestGitHubData}
     />
   );

--- a/src/components/local-block.tsx
+++ b/src/components/local-block.tsx
@@ -103,7 +103,8 @@ export const LocalBlock = (props: LocalBlockProps) => {
       metadata={metadata}
       onUpdateMetadata={onUpdateMetadata}
       onNavigateToPath={onNavigateToPath}
-      onRequestUpdateContent={setContent}
+      onUpdateContent={setContent}
+      onRequestUpdateContent={setContent} // for backward compatibility
       onRequestGitHubData={onRequestGitHubData}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,10 +816,10 @@
     unist-util-visit "^1.0.0"
     uuid "^3.3.2"
 
-"@githubnext/utils@^0.19.7":
-  version "0.19.7"
-  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.19.7.tgz#c2a29cce364c8de3df4b6c224f566cec59b33454"
-  integrity sha512-gl4a7YfcYmCJuSaZRi4BMTq9Lmfvx4U4k5OzMoISh1auAUPwEwR2F8XNlIsaqVtf9wkWGR6iUkz1UR22BzgCtw==
+"@githubnext/utils@^0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.20.0.tgz#69d245ac9806e1575177a99d0e6c906a8412b603"
+  integrity sha512-M7CbTe/sasvZbzvbNJ8q+NqMda+hUZpTYgWH0qmnvcY1sHjiBd+abFGiq9PG1RwRoMKeMRDfHjfeMkVakC+Utg==
   dependencies:
     "@types/lodash.uniqueid" "^4.0.6"
     lodash.uniqueid "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,10 +816,10 @@
     unist-util-visit "^1.0.0"
     uuid "^3.3.2"
 
-"@githubnext/utils@^0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.20.0.tgz#69d245ac9806e1575177a99d0e6c906a8412b603"
-  integrity sha512-M7CbTe/sasvZbzvbNJ8q+NqMda+hUZpTYgWH0qmnvcY1sHjiBd+abFGiq9PG1RwRoMKeMRDfHjfeMkVakC+Utg==
+"@githubnext/utils@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.21.0.tgz#d564718803e68e53258382766212585831bb48fa"
+  integrity sha512-gRRasLrE3l4R7J73wdMlVko6N+/rh1GjCm5wPlaSaUkcAL8corlBz1mJQ7TyvD9/LJMUy1X9X7pnqNEjVZsHyA==
   dependencies:
     "@types/lodash.uniqueid" "^4.0.6"
     lodash.uniqueid "^4.0.1"


### PR DESCRIPTION
* use `onUpdateContent` instead of `onRequestUpdateContent`
* handle the new `isEditable` prop where it makes sense (in the Flat, CodeMirror, Excalidraw, JSON, and Poll blocks)
* handle the new `originalContent` props where it makes sense (just the Flat block)

This depends on https://github.com/githubnext/blocks/pull/135.

It doesn't yet handle production mode correctly because of the `onRequestUpdateContent` -> `onUpdateContent` change. I will update once https://github.com/githubnext/utils/pull/16 is in before merging.

I found a bug with the Excalidraw block and the new save button — the `onChange` handler is called immediately on mounting with values that, when serialized, do not match the original content — but I'll fix it in a separate branch.