### PR TITLE
use `onRequestBlocksRepos` instead of marketplace API

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
     "@excalidraw/excalidraw": "^0.10.0",
     "@fullstackio/cq": "^6.0.9",
     "@fullstackio/remark-cq": "^6.1.2",
-    "@githubnext/utils": "^0.22.0",
+    "@githubnext/utils": "^0.23.0",
     "@githubocto/flat-ui": "^0.14.1",
     "@loadable/component": "^5.15.0",
     "@mdx-js/runtime": "2.0.0-next.9",

--- a/src/blocks/folder-blocks/dashboard/index.tsx
+++ b/src/blocks/folder-blocks/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import { tw } from "twind";
 import { useEffect, useMemo, useState } from "react";
-import { FolderBlockProps } from "@githubnext/utils";
+import { Block, FolderBlockProps } from "@githubnext/utils";
 import Select from "react-select";
 import { Box, Button, IconButton } from "@primer/react";
 import { TrashIcon } from "@primer/octicons-react";
@@ -9,8 +9,14 @@ import { TrashIcon } from "@primer/octicons-react";
 // This is only implemented for our own example Blocks, to showcase the concept.
 
 export default function (props: FolderBlockProps) {
-  const { tree, metadata = {}, onUpdateMetadata, BlockComponent } = props;
-  const [blockOptions, setBlockOptions] = useState<any>([]);
+  const {
+    tree,
+    metadata = {},
+    onUpdateMetadata,
+    BlockComponent,
+    onRequestBlocksRepos,
+  } = props;
+  const [blockOptions, setBlockOptions] = useState<Block[]>([]);
   const [blocks, setBlocks] = useState<any>(metadata?.blocks || defaultBlocks);
   useEffect(() => setBlocks(metadata?.blocks || blocks), [metadata]);
   const pathOptions = useMemo(
@@ -21,8 +27,8 @@ export default function (props: FolderBlockProps) {
     [tree]
   );
   const blockOptionsByType = {
-    folder: blockOptions.filter((d: any) => d.type === "folder"),
-    file: blockOptions.filter((d: any) => d.type === "file"),
+    folder: blockOptions.filter((block) => block.type === "folder"),
+    file: blockOptions.filter((block) => block.type === "file"),
   };
   const isDirty =
     JSON.stringify(blocks) !== JSON.stringify(metadata?.blocks || blocks);
@@ -44,13 +50,13 @@ export default function (props: FolderBlockProps) {
   };
 
   const getBlocks = async () => {
-    const url = "https://blocks-marketplace.githubnext.com/api/blocks";
-    const res = await fetch(url).then((res) => res.json());
+    const blocksRepos = await onRequestBlocksRepos();
     const exampleBlocks =
-      res.find((d: any) => d.full_name === "githubnext/blocks-examples")
-        ?.blocks || [];
+      blocksRepos.find(
+        (repo) => repo.full_name === "githubnext/blocks-examples"
+      )?.blocks || [];
     setBlockOptions(
-      exampleBlocks.map((block: any) => ({
+      exampleBlocks.map((block) => ({
         ...block,
         owner: "githubnext",
         repo: "blocks-examples",

--- a/src/blocks/folder-blocks/infinite-canvas/BlockPicker.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/BlockPicker.tsx
@@ -1,7 +1,7 @@
 import { tw } from "twind";
 import { ActionList, ActionMenu } from "@primer/react";
 import { useState } from "react";
-import { Block } from "./index";
+import { BlockWithKey as Block } from "./index";
 
 export const BlockPicker = ({
   value,
@@ -10,7 +10,7 @@ export const BlockPicker = ({
 }: {
   value: Block;
   onChange: (newBlock: Block) => void;
-  options: any[];
+  options: Block[];
 }) => {
   // needed to close the dropdown, which is an uncontrolled detail element
   const [iteration, setIteration] = useState(0);

--- a/src/blocks/folder-blocks/infinite-canvas/index.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/index.tsx
@@ -1,5 +1,5 @@
 import { tw } from "twind";
-import { FolderBlockProps, getNestedFileTree } from "@githubnext/utils";
+import { Block, FolderBlockProps, getNestedFileTree } from "@githubnext/utils";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Buffer } from "buffer";
 import { FilePicker } from "./FilePicker";
@@ -11,7 +11,7 @@ import { Button } from "@primer/react";
 
 const width = 5000;
 const height = 5000;
-const defaultDimensions = [200, 100];
+const defaultDimensions: [number, number] = [200, 100];
 export default function (
   props: FolderBlockProps & {
     metadata: { items: ItemType[] };
@@ -24,6 +24,7 @@ export default function (
     BlockComponent,
     onUpdateMetadata,
     onRequestGitHubData,
+    onRequestBlocksRepos,
   } = props;
 
   const wrapperElement = useRef<HTMLDivElement>(null);
@@ -96,22 +97,21 @@ export default function (
     setItems(metadata.items || placeholderItems);
   }, [metadata]);
 
-  const [blockOptions, setBlockOptions] = useState<any[]>([]);
+  const [blockOptions, setBlockOptions] = useState<Block[]>([]);
 
   const getBlocks = async () => {
-    const url = "https://blocks-marketplace.githubnext.com/api/blocks";
-    const res = await fetch(url).then((res) => res.json());
-    const exampleBlocks = res || [];
+    const blocksRepos = await onRequestBlocksRepos();
+    const exampleBlocks = blocksRepos || [];
     setBlockOptions(
       flatten(
-        exampleBlocks.map((blocksRepo: any) =>
+        exampleBlocks.map((blocksRepo) =>
           blocksRepo.blocks.map((block) => ({
             ...block,
             owner: blocksRepo.owner,
             repo: blocksRepo.repo,
           }))
         )
-      ).map((block: Block) => ({
+      ).map((block) => ({
         ...block,
         key: getBlockKey(block),
       }))
@@ -162,6 +162,7 @@ export default function (
                   type: "file",
                   id: "code-block",
                   title: "Code block",
+                  description: "A basic code block",
                   owner: "githubnext",
                   repo: "blocks-examples",
                   sandbox: false,
@@ -286,6 +287,6 @@ export type ItemType = {
   position: Position;
   dimensions: Dimensions;
 };
-export type Block = any;
+export type BlockWithKey = Block & { key: string };
 export type Files = ReturnType<typeof getNestedFileTree>;
 export type File = Files[0];

--- a/src/blocks/folder-blocks/infinite-canvas/index.tsx
+++ b/src/blocks/folder-blocks/infinite-canvas/index.tsx
@@ -11,7 +11,7 @@ import { Button } from "@primer/react";
 
 const width = 5000;
 const height = 5000;
-const defaultDimensions: [number, number] = [200, 100];
+const defaultDimensions: Dimensions = [200, 100];
 export default function (
   props: FolderBlockProps & {
     metadata: { items: ItemType[] };

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,14 +816,13 @@
     unist-util-visit "^1.0.0"
     uuid "^3.3.2"
 
-"@githubnext/utils@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.22.0.tgz#70fba0ca4ddb5dc5979d7e5711da0581674f2461"
-  integrity sha512-F/ay94PL8c/gK8ks7CkQGYDwiUJo5h+ccnbfzzBovT/MudkIseSut8qkP+br7JT0lBrmAmMQAzTsQaMcz2j2pg==
+"@githubnext/utils@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@githubnext/utils/-/utils-0.23.0.tgz#eb00ef15adf57fdcc5005e911afa7526099f1976"
+  integrity sha512-/t5iMsEr0PFTVUexgMsIOLwb1T0BbJlvmYwe3XexjrIgxgueSLBnaw51eb21vqnHClhw3ZmBDLz1TUkUe6cQ8g==
   dependencies:
     "@types/lodash.uniqueid" "^4.0.6"
     lodash.uniqueid "^4.0.1"
-    zod "^3.11.6"
 
 "@githubocto/flat-ui@^0.14.1":
   version "0.14.1"
@@ -8462,11 +8461,6 @@ yargs@^4.7.1:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
-
-zod@^3.11.6:
-  version "3.14.3"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.14.3.tgz#60e86341c05883c281fe96a0e79acea48a09f123"
-  integrity sha512-OzwRCSXB1+/8F6w6HkYHdbuWysYWnAF4fkRgKDcSFc54CE+Sv0rHXKfeNUReGCrHukm1LNpi6AYeXotznhYJbQ==
 
 zstddec@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
I wasn't able to test this yet; the dashboard and infinite canvas blocks don't work in this environment *, so I didn't bother implementing `onRequestBlocksRepos` here. Next I'm going to implement `onRequestBlocksRepos` in `blocks` so I'll be able to test these changes there.

\* = `BlockComponent` is not provided, and also `picomatch` can't be loaded — these issues exist already on `main`