### PR TITLE
feat: check scene version before updating

### DIFF
--- a/blocks/file-blocks/excalidraw/index.tsx
+++ b/blocks/file-blocks/excalidraw/index.tsx
@@ -19,6 +19,7 @@ export default function (props: FileBlockProps) {
   const [version, setVersion] = useState<number | null>(null);
 
   useEffect(() => {
+    if (excalModule) return;
     import("@excalidraw/excalidraw").then((imp) => {
       setExcalModule(imp);
       try {

--- a/blocks/file-blocks/excalidraw/index.tsx
+++ b/blocks/file-blocks/excalidraw/index.tsx
@@ -16,10 +16,16 @@ if (typeof window !== "undefined") {
 export default function (props: FileBlockProps) {
   const { context, content, isEditable, onUpdateContent } = props;
   const [excalModule, setExcalModule] = useState<any>(null);
+  const [version, setVersion] = useState<number | null>(null);
 
   useEffect(() => {
     import("@excalidraw/excalidraw").then((imp) => {
       setExcalModule(imp);
+      try {
+        const parsed = JSON.parse(content);
+        const elements = parsed?.elements || [];
+        setVersion(imp.getSceneVersion(elements));
+      } catch {}
     });
   }, []);
 
@@ -28,7 +34,9 @@ export default function (props: FileBlockProps) {
       console.error("Excalidraw is not loaded.");
       return;
     }
+    const newVersion = excalModule.getSceneVersion(elements);
     const serialized = excalModule.serializeAsJSON(elements, appState);
+    if (newVersion === version) return;
     onUpdateContent(serialized);
   };
 


### PR DESCRIPTION
This PR fixes a workflow issue with the Excalidraw block where we create a ghost commit when the block loads.

I notice that the Excalidraw component's `onChange` handler gets called pretty frequently. This in turn is triggering our `onUpdateContent` callback which results in a ghost commit appearing.

I had an idea wherein we cache the scene's version via the `getSceneVersion` utility function. We can check if this version number matches what comes through when `onChange` is fired and either: A) return early; B) update the document and cache the new version number.

I might be missing something here or not fully seeing all of the edge cases 🤷 