### PR TITLE
Implement onFetchInternalEndpoint

### DIFF
--- a/blocks/file-blocks/edit/index.tsx
+++ b/blocks/file-blocks/edit/index.tsx
@@ -13,7 +13,7 @@ import { Button, FormControl, TextInput } from "@primer/react";
 export default function (props: FileBlockProps) {
   const { content, context, onUpdateContent } = props;
   const onFetchInternalEndpoint =
-    props.onFetchInternalEndpoint || onFetchInternalEndpointPolyfill;
+    props.private__onFetchInternalEndpoint || onFetchInternalEndpointPolyfill;
 
   const [instruction, setInstruction] = useState<string>("");
   const [newContent, setNewContent] = useState<string>("");

--- a/blocks/file-blocks/edit/index.tsx
+++ b/blocks/file-blocks/edit/index.tsx
@@ -55,7 +55,7 @@ export default function (props: FileBlockProps) {
               input: content,
             },
           });
-          setNewContent(res);
+          setNewContent(res.data);
           setIsLoading(false);
         }}
       >
@@ -203,6 +203,5 @@ const Change = ({ change, language }: { change: Hunk; language: string }) => {
 };
 
 const onFetchInternalEndpointPolyfill = async (url: string, params: any) => {
-  const res = await axios(url, params);
-  return res.data;
+  return await axios(url, params);
 };

--- a/blocks/file-blocks/edit/index.tsx
+++ b/blocks/file-blocks/edit/index.tsx
@@ -12,6 +12,8 @@ import { Button, FormControl, TextInput } from "@primer/react";
 
 export default function (props: FileBlockProps) {
   const { content, context, onUpdateContent } = props;
+  const onFetchInternalEndpoint =
+    props.onFetchInternalEndpoint || onFetchInternalEndpointPolyfill;
 
   const [instruction, setInstruction] = useState<string>("");
   const [newContent, setNewContent] = useState<string>("");
@@ -46,11 +48,14 @@ export default function (props: FileBlockProps) {
         onSubmit={async (e) => {
           e.preventDefault();
           setIsLoading(true);
-          const res = await axios.post("/api/openai-edit", {
-            instruction: instruction,
-            input: content,
+          const res = await onFetchInternalEndpoint("/api/openai-edit", {
+            method: "POST",
+            data: {
+              instruction: instruction,
+              input: content,
+            },
           });
-          setNewContent(res.data);
+          setNewContent(res);
           setIsLoading(false);
         }}
       >
@@ -195,4 +200,9 @@ const Change = ({ change, language }: { change: Hunk; language: string }) => {
       </SyntaxHighlighter>
     </div>
   );
+};
+
+const onFetchInternalEndpointPolyfill = async (url: string, params: any) => {
+  const res = await axios(url, params);
+  return res.data;
 };

--- a/blocks/file-blocks/explain/explanation.tsx
+++ b/blocks/file-blocks/explain/explanation.tsx
@@ -24,7 +24,7 @@ export function ExplanationComponent(props: {
 }) {
   const { explanation } = props;
   const onFetchInternalEndpoint =
-    props.onFetchInternalEndpoint || onFetchInternalEndpointPolyfill;
+    props.private__onFetchInternalEndpoint || onFetchInternalEndpointPolyfill;
 
   const { data, status } = useQuery(
     ["explanation", props.explanation.code],

--- a/blocks/file-blocks/explain/explanation.tsx
+++ b/blocks/file-blocks/explain/explanation.tsx
@@ -66,6 +66,5 @@ export function ExplanationComponent(props: {
 }
 
 const onFetchInternalEndpointPolyfill = async (url: string, params: any) => {
-  const res = await axios(url, params);
-  return res.data;
+  return await axios(url, params);
 };

--- a/blocks/file-blocks/explain/explanation.tsx
+++ b/blocks/file-blocks/explain/explanation.tsx
@@ -3,10 +3,17 @@ import axios from "axios";
 import { useQuery } from "react-query";
 import type { Explanation } from ".";
 
-const fetchExplanation = async (code: string, language: string) => {
-  const res = await axios.post(`/api/explain`, {
-    code,
-    language,
+const fetchExplanation = async (
+  code: string,
+  language: string,
+  onFetchInternalEndpoint: (url: string, params: any) => Promise<any>
+): Promise<Explanation> => {
+  const res = await onFetchInternalEndpoint("/api/explain", {
+    method: "POST",
+    data: {
+      code,
+      language,
+    },
   });
   return res.data;
 };
@@ -16,9 +23,17 @@ export function ExplanationComponent(props: {
   language: string;
 }) {
   const { explanation } = props;
+  const onFetchInternalEndpoint =
+    props.onFetchInternalEndpoint || onFetchInternalEndpointPolyfill;
+
   const { data, status } = useQuery(
     ["explanation", props.explanation.code],
-    () => fetchExplanation(props.explanation.code, props.language),
+    () =>
+      fetchExplanation(
+        props.explanation.code,
+        props.language,
+        onFetchInternalEndpoint
+      ),
     { refetchOnWindowFocus: false }
   );
 
@@ -49,3 +64,8 @@ export function ExplanationComponent(props: {
     </>
   );
 }
+
+const onFetchInternalEndpointPolyfill = async (url: string, params: any) => {
+  const res = await axios(url, params);
+  return res.data;
+};

--- a/blocks/file-blocks/summarize/index.tsx
+++ b/blocks/file-blocks/summarize/index.tsx
@@ -9,6 +9,8 @@ import "./index.css";
 
 export default function (props: FileBlockProps) {
   const { content, context } = props;
+  const onFetchInternalEndpoint =
+    props.onFetchInternalEndpoint || onFetchInternalEndpointPolyfill;
   const [sections, setSections] = useState<CodeSection[]>([]);
   const [sectionExplanations, setSectionExplanations] = useState<string[]>([]);
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
@@ -39,7 +41,7 @@ export default function (props: FileBlockProps) {
         type === "function" &&
         // don't hammer the endpoint
         index < 30
-          ? await fetchCodeSummary(text, language)
+          ? await fetchCodeSummary(text, language, onFetchInternalEndpoint)
           : "";
       setSectionExplanations((sectionExplanations) => {
         let newSectionExplanations = [...sectionExplanations];
@@ -191,9 +193,13 @@ const Section = ({
   );
 };
 
-const fetchCodeSummary = async (code: string, language: string) => {
+const fetchCodeSummary = async (
+  code: string,
+  language: string,
+  onFetchInternalEndpoint: (url: string, params: any) => Promise<any>
+) => {
   // this is an endpoint on the main prototype
-  const response = await axios("/api/explain", {
+  const response = await onFetchInternalEndpoint("/api/explain", {
     method: "POST",
     data: {
       language,
@@ -281,4 +287,9 @@ const breakCodeIntoSections = async (
     });
   });
   return sections.filter((d) => !!d.text.trim());
+};
+
+const onFetchInternalEndpointPolyfill = async (url: string, params: any) => {
+  const res = await axios(url, params);
+  return res.data;
 };

--- a/blocks/file-blocks/summarize/index.tsx
+++ b/blocks/file-blocks/summarize/index.tsx
@@ -10,7 +10,7 @@ import "./index.css";
 export default function (props: FileBlockProps) {
   const { content, context } = props;
   const onFetchInternalEndpoint =
-    props.onFetchInternalEndpoint || onFetchInternalEndpointPolyfill;
+    props.private__onFetchInternalEndpoint || onFetchInternalEndpointPolyfill;
   const [sections, setSections] = useState<CodeSection[]>([]);
   const [sectionExplanations, setSectionExplanations] = useState<string[]>([]);
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);

--- a/blocks/file-blocks/summarize/index.tsx
+++ b/blocks/file-blocks/summarize/index.tsx
@@ -290,6 +290,5 @@ const breakCodeIntoSections = async (
 };
 
 const onFetchInternalEndpointPolyfill = async (url: string, params: any) => {
-  const res = await axios(url, params);
-  return res.data;
+  return await axios(url, params);
 };


### PR DESCRIPTION
We need a backdoor for Blocks to use endpoints on githubnext/blocks - hitting them directly will no longer work once githubnext#139 is merged in.