### PR TITLE
Fix a couple blocks that don't handle receiving new props well

### DIFF
--- a/blocks/file-blocks/excalidraw/index.tsx
+++ b/blocks/file-blocks/excalidraw/index.tsx
@@ -14,7 +14,7 @@ if (typeof window !== "undefined") {
   }
 }
 export default function (props: FileBlockProps) {
-  const { content, isEditable, onUpdateContent } = props;
+  const { context, content, isEditable, onUpdateContent } = props;
   const [excalModule, setExcalModule] = useState<any>(null);
   const version = useRef<number>(null);
   const key = useRef<number>(0);
@@ -51,7 +51,11 @@ export default function (props: FileBlockProps) {
   const ExcalidrawComponent = excalModule ? excalModule.default : null;
 
   return (
-    <div className={tw(`width-full`)} style={{ height: "100vh" }}>
+    <div
+      className={tw(`width-full`)}
+      style={{ height: "100vh" }}
+      key={context.sha}
+    >
       {ExcalidrawComponent && (
         <ExcalidrawComponent
           key={String(key.current)}


### PR DESCRIPTION
Fix a couple blocks that don't handle receiving new props well, so we can drop the `key` when the block is rendered in `blocks-sandbox` (so blocks that *do* handle receiving new props well don't needlessly remount).

For the code block: use CodeMirror compartments to reconfigure the editor when the `path` or `isEditable` flags change.

For the Excalidraw block: add a key to remount the component when the SHA changes (Excalidraw's API doesn't make it easy to reconfigure the component with new content).