### PR TITLE
[feat] stable IDs for infinite canvas to reduce redraws

### DIFF
--- a/blocks/folder-blocks/infinite-canvas/Item.tsx
+++ b/blocks/folder-blocks/infinite-canvas/Item.tsx
@@ -11,10 +11,7 @@ export const Item = ({
   type,
   text,
   path,
-  url,
   block,
-  blockProps,
-  contents = "",
   position,
   dimensions,
   blockOptions = [],
@@ -22,10 +19,8 @@ export const Item = ({
   onDelete,
   onChange,
 }: ItemType & {
-  contents?: string;
   blockOptions: any[];
   BlockComponent?: any;
-  blockProps?: any;
   onDelete: () => void;
   onChange: (newContents: Partial<ItemType>) => void;
 }) => {
@@ -46,7 +41,6 @@ export const Item = ({
 
   const relevantBlockOptions = useMemo(() => {
     if (type !== "file") return null;
-    const extension = path?.split(".").pop();
     return blockOptions.filter((block: any) => {
       // don't include example Blocks
       if (block.title === "Example File Block") {
@@ -143,36 +137,12 @@ export const Item = ({
                 options={relevantBlockOptions || []}
               />
             </div>
-            {BlockComponent && block ? (
+            {BlockComponent && block && (
               <div className={tw(`w-full flex-1`)}>
                 <div className={tw(`scaled-down`)}>
-                  <BlockComponent
-                    {...(blockProps || {})}
-                    block={block}
-                    path={path} // soon to be deprecated, leaving for backwards compatibility
-                    context={{
-                      path,
-                    }}
-                    content={contents}
-                    onRequestGitHubData={async (...args) => {
-                      // catch API errors
-                      try {
-                        return await blockProps.onRequestGitHubData(...args);
-                      } catch (e) {
-                        console.error(e);
-                      }
-                    }}
-                  />
+                  <BlockComponent block={block} context={{ path }} />
                 </div>
               </div>
-            ) : (
-              <pre
-                className={tw(
-                  `text-xs pl-[1.7em] overflow-auto py-1 text-gray-500`
-                )}
-              >
-                {contents}
-              </pre>
             )}
           </div>
         ) : null}

--- a/blocks/folder-blocks/infinite-canvas/index.tsx
+++ b/blocks/folder-blocks/infinite-canvas/index.tsx
@@ -100,6 +100,17 @@ export default function (
     getBlocks();
   }, []);
 
+  const addItem = (item: Omit<ItemType, "id">) => {
+    const id = nextId.current;
+    nextId.current += 1;
+    const newItems: { [id: number]: ItemType } = {
+      ...items,
+      [id]: { ...item, id },
+    };
+    setItems(newItems);
+    setIsDirty(true);
+  };
+
   return (
     <div className={tw(`wrapper`)}>
       {/* add new item buttons */}
@@ -107,23 +118,15 @@ export default function (
         {/* add text */}
         <Button
           onClick={() => {
-            const id = nextId.current;
-            nextId.current += 1;
-            const newItems: { [id: number]: ItemType } = {
-              ...items,
-              [id]: {
-                id,
-                type: "text",
-                text: "Hello World",
-                position: [
-                  width / 2 - defaultDimensions[0] / 2,
-                  height / 2 - defaultDimensions[1] / 2,
-                ],
-                dimensions: defaultDimensions,
-              },
-            };
-            setItems(newItems);
-            setIsDirty(true);
+            addItem({
+              type: "text",
+              text: "Hello World",
+              position: [
+                width / 2 - defaultDimensions[0] / 2,
+                height / 2 - defaultDimensions[1] / 2,
+              ],
+              dimensions: defaultDimensions,
+            });
           }}
         >
           + Add text
@@ -133,30 +136,22 @@ export default function (
         <FilePicker
           files={files}
           onFileSelected={(file) => {
-            const id = nextId.current;
-            nextId.current += 1;
-            const newItems: { [id: number]: ItemType } = {
-              ...items,
-              [id]: {
-                id,
+            addItem({
+              type: "file",
+              path: file.path,
+              position: [width / 2 - 500 / 2, height / 2 - 360 / 2],
+              dimensions: [500, 360],
+              block: {
                 type: "file",
-                path: file.path,
-                position: [width / 2 - 500 / 2, height / 2 - 360 / 2],
-                dimensions: [500, 360],
-                block: {
-                  type: "file",
-                  id: "code-block",
-                  title: "Code block",
-                  description: "A basic code block",
-                  owner: "githubnext",
-                  repo: "blocks-examples",
-                  sandbox: false,
-                  entry: "/src/blocks/file-blocks/code/index.tsx",
-                },
+                id: "code-block",
+                title: "Code block",
+                description: "A basic code block",
+                owner: "githubnext",
+                repo: "blocks-examples",
+                sandbox: false,
+                entry: "/src/blocks/file-blocks/code/index.tsx",
               },
-            };
-            setItems(newItems);
-            setIsDirty(true);
+            });
           }}
         />
       </div>

--- a/blocks/folder-blocks/infinite-canvas/index.tsx
+++ b/blocks/folder-blocks/infinite-canvas/index.tsx
@@ -71,7 +71,7 @@ export default function (
       items = items.reduce(
         (items, item, id) => ({
           ...items,
-          id: { ...item, id },
+          [id]: { ...item, id },
         }),
         {}
       );
@@ -109,9 +109,9 @@ export default function (
           onClick={() => {
             const id = nextId.current;
             nextId.current += 1;
-            const newItems = {
+            const newItems: { [id: number]: ItemType } = {
               ...items,
-              id: {
+              [id]: {
                 id,
                 type: "text",
                 text: "Hello World",
@@ -135,9 +135,9 @@ export default function (
           onFileSelected={(file) => {
             const id = nextId.current;
             nextId.current += 1;
-            const newItems = {
+            const newItems: { [id: number]: ItemType } = {
               ...items,
-              id: {
+              [id]: {
                 id,
                 type: "file",
                 path: file.path,
@@ -192,7 +192,7 @@ export default function (
               onChange={(newContents: Partial<ItemType>) => {
                 setItems({
                   ...items,
-                  [item.id]: { ...items[item.id], ...newContents },
+                  [item.id]: { ...item, ...newContents },
                 });
                 setIsDirty(true);
               }}

--- a/blocks/folder-blocks/infinite-canvas/index.tsx
+++ b/blocks/folder-blocks/infinite-canvas/index.tsx
@@ -190,10 +190,10 @@ export default function (
               blockOptions={blockOptions}
               BlockComponent={BlockComponent}
               onChange={(newContents: Partial<ItemType>) => {
-                setItems({
+                setItems((items) => ({
                   ...items,
-                  [item.id]: { ...item, ...newContents },
-                });
+                  [item.id]: { ...items[item.id], ...newContents },
+                }));
                 setIsDirty(true);
               }}
               onDelete={() => {


### PR DESCRIPTION
In the current code, panes on the infinite canvas are keyed by their array position, so if you remove a pane all subsequent panes in the array are remounted. This change assigns stable keys so this doesn't happen. (And while we're here removes some stuff that isn't needed with the new sandboxing changes—this shouldn't be merged / tagged until those changes are deployed.)
