### PR TITLE
feat: use new `buildTree` utility function

### DIFF
--- a/blocks/folder-blocks/infinite-canvas/FilePicker.tsx
+++ b/blocks/folder-blocks/infinite-canvas/FilePicker.tsx
@@ -1,34 +1,31 @@
 import { tw } from "twind";
 import { ActionList, ActionMenu } from "@primer/react";
-
-import { useState } from "react";
-import { Files, File } from "./index";
+import { TreeNode } from "@githubnext/blocks";
 
 export const FilePicker = ({
   files,
   onFileSelected,
 }: {
-  files: Files;
-  onFileSelected: (file: File) => void;
+  files: TreeNode[];
+  onFileSelected: (path: string) => void;
 }) => {
-  // needed to close the dropdown, which is an uncontrolled detail element
-  const [iteration, setIteration] = useState(0);
-
   return (
     <ActionMenu>
       <ActionMenu.Button>+ File</ActionMenu.Button>
 
       <ActionMenu.Overlay>
-        <ActionList>
+        <ActionList
+          variant="full"
+          className={tw(`max-h-[300px] p-1 overflow-y-auto`)}
+        >
           {files.map((file) => {
             return (
               <ActionList.Item
                 onSelect={() => {
-                  onFileSelected(file);
-                  setIteration(iteration + 1);
+                  onFileSelected(file.meta.path);
                 }}
                 key={file.path}
-                className={tw(`dropdown-item text-sm w-full`)}
+                className={tw(`text-sm w-full`)}
               >
                 {file.path}
               </ActionList.Item>

--- a/blocks/folder-blocks/infinite-canvas/index.tsx
+++ b/blocks/folder-blocks/infinite-canvas/index.tsx
@@ -1,5 +1,10 @@
 import { tw } from "twind";
-import { Block, FolderBlockProps, getNestedFileTree } from "@githubnext/blocks";
+import {
+  Block,
+  FolderBlockProps,
+  getNestedFileTree,
+  buildTree,
+} from "@githubnext/blocks";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { FilePicker } from "./FilePicker";
 import { useDrag } from "./useDrag";
@@ -24,6 +29,7 @@ export default function (
     onRequestBlocksRepos,
   } = props;
   const nextId = useRef(0);
+  const { path } = props.context;
 
   const wrapperElement = useRef<HTMLDivElement>(null);
 
@@ -60,10 +66,11 @@ export default function (
   const [items, setItems] = useState<{ [id: number]: ItemType }>({});
   const [isDirty, setIsDirty] = useState(false);
 
-  const files = useMemo(
-    () => getNestedFileTree(tree)[0].children.filter((d) => d.type === "blob"),
-    [tree]
-  );
+  const builtTree = buildTree(tree);
+
+  const files = useMemo(() => {
+    return builtTree.getDirectoryFiles(path, { recursive: true });
+  }, [path]);
 
   useEffect(() => {
     let items = metadata.items || placeholderItems;
@@ -135,10 +142,10 @@ export default function (
         {/* add new file */}
         <FilePicker
           files={files}
-          onFileSelected={(file) => {
+          onFileSelected={(path) => {
             addItem({
+              path,
               type: "file",
-              path: file.path,
               position: [width / 2 - 500 / 2, height / 2 - 360 / 2],
               dimensions: [500, 360],
               block: {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@excalidraw/excalidraw": "^0.10.0",
     "@fullstackio/cq": "^6.0.9",
     "@fullstackio/remark-cq": "^6.1.2",
-    "@githubnext/blocks": "^2.2.0",
+    "@githubnext/blocks": "^2.4.0-1",
     "@githubocto/flat-ui": "^0.14.1",
     "@lezer/highlight": "^1.0.0",
     "@lezer/markdown": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,15 +910,36 @@
     unist-util-visit "^1.0.0"
     uuid "^3.3.2"
 
-"@githubnext/blocks@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@githubnext/blocks/-/blocks-2.2.0.tgz#e060b8718621fd7917f4dca4c68d178d9e7b93b8"
-  integrity sha512-as89UwPi3tQPYDjaAmRKYa/lndUH6ZW9gcZIuXiUnGWSpzn6qZyQTMA2NNpm7sjy9nOy6mtw3RYGt/EfJeIqdw==
+"@github/combobox-nav@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@github/combobox-nav/-/combobox-nav-2.1.5.tgz#905598cc681e016eddfcd8adcb39e4d81c907577"
+  integrity sha512-dmG1PuppNKHnBBEcfylWDwj9SSxd/E/qd8mC1G/klQC3s7ps5q6JZ034mwkkG0LKfI+Y+UgEua/ROD776N400w==
+
+"@github/markdown-toolbar-element@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.1.1.tgz#08a0696be1006b42b6b29560104f1bca20341b06"
+  integrity sha512-J++rpd5H9baztabJQB82h26jtueOeBRSTqetk9Cri+Lj/s28ndu6Tovn0uHQaOKtBWDobFunk9b5pP5vcqt7cA==
+
+"@github/paste-markdown@^1.4.0":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@github/paste-markdown/-/paste-markdown-1.4.2.tgz#aedba0972536c2fc7944931b6e62bd43dc130592"
+  integrity sha512-ZwSgPyo9nA6TRngXV0QnFT4e5ujeOGxRDWN2aa6qfimz2o2VOsJ9bFGuGvB723nvzq5z9zKr6JWGtvK7MSJj3w==
+
+"@github/relative-time-element@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@github/relative-time-element/-/relative-time-element-4.1.2.tgz#8cfceb2a8bbb66e145f2fd18330e151f9b47118b"
+  integrity sha512-34izL9UqcgU2ZkziZVGuxQoCsswLM5jQ7Q7PYZ04GByaFASg8rdyZrLW3SaWzTFghANfr6l00RMBhjPX6PtxNw==
+
+"@githubnext/blocks@^2.4.0-1":
+  version "2.4.0-1"
+  resolved "https://registry.yarnpkg.com/@githubnext/blocks/-/blocks-2.4.0-1.tgz#da05454983bde9f0aa2e44eb6023212e27f7c3f2"
+  integrity sha512-xeS2Ap87Xoe7gyyltfYm5s3VvDBK1X5Qrw6b30jccwL/+Tet9musTEOzecLmpnQX7rynwj2Z3Q25OClq7YGB/Q==
   dependencies:
     "@loadable/component" "^5.15.0"
-    "@octokit/openapi-types" "^11.2.0"
+    "@octokit/openapi-types" "^12.11.0"
+    "@octokit/types" "^6.0.0"
     "@primer/octicons-react" "^17.3.0"
-    "@primer/react" "^35.2.1"
+    "@primer/react" "^35.15.1"
     "@vitejs/plugin-react" "^2.0.1"
     chalk "^4.1.2"
     chokidar "^3.5.3"
@@ -1157,6 +1178,11 @@
     "@lezer/highlight" "^1.0.0"
     "@lezer/lr" "^1.0.0"
 
+"@lit-labs/react@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@lit-labs/react/-/react-1.0.9.tgz#0703ed89fcdfd2766bc71c18ccb6b06c4bbe6019"
+  integrity sha512-yjkdcciypTIJ6vUXzZJHTAwt2fdATUAfZMkHRbLpbgEnr8OwpwVOQ04me1Y7p5Vwtmcd4GWY0/BQ6G8jUgCK1w==
+
 "@loadable/component@^5.15.0":
   version "5.15.2"
   resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.15.2.tgz#b6c418d592e0a64f16b1d614ca9d3b1443d3b498"
@@ -1292,11 +1318,6 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^11.2.0":
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
-  integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
-
 "@octokit/openapi-types@^12.11.0":
   version "12.11.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-12.11.0.tgz#da5638d64f2b919bca89ce6602d059f1b52d3ef0"
@@ -1358,7 +1379,7 @@
     "@octokit/plugin-request-log" "^1.0.4"
     "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
 
-"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.39.0", "@octokit/types@^6.40.0":
+"@octokit/types@^6.0.0", "@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.39.0", "@octokit/types@^6.40.0":
   version "6.41.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.41.0.tgz#e58ef78d78596d2fb7df9c6259802464b5f84a04"
   integrity sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==
@@ -1376,6 +1397,11 @@
   version "3.6.6"
   resolved "https://registry.yarnpkg.com/@petamoriken/float16/-/float16-3.6.6.tgz#641f73913a6be402b34e4bdfca98d6832ed55586"
   integrity sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg==
+
+"@primer/behaviors@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@primer/behaviors/-/behaviors-1.3.1.tgz#febae28e5f7824f1fa547389b3ff8563e171da58"
+  integrity sha512-aMRDUQ350lk0FxtL5gJWPFHHOSSzDbJ6uNJVIt8XSqiGe1pxuW5mVVfrEp1uvzZ0pCHkCdm9fycjnfOeMeIrOQ==
 
 "@primer/behaviors@^1.1.1":
   version "1.1.3"
@@ -1397,6 +1423,16 @@
   resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-17.4.1.tgz#022c13c2695119f5e2e5fc3e2edeed08164171c1"
   integrity sha512-xTtpfgpyFyKlfNhvPOfCNVRwkoDBRKzZFwygpr4+Pwzs+selrL1phPLt2z6abeIY8cTEw1XRBGi00tylSaBJyQ==
 
+"@primer/octicons-react@^17.7.0":
+  version "17.10.1"
+  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-17.10.1.tgz#38ac186f086eda0e83feb198978bb1c9d0067af8"
+  integrity sha512-27F3OyrZVifha5bw84lVnuoxcLWaQFiOZ840itfvzRqlDD03q+bUb0wrw26+hGbbXuX8I65rzxh75T32blZFIw==
+
+"@primer/primitives@7.10.0":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.10.0.tgz#de0d9648d484184442583564f02d6600b872fa5f"
+  integrity sha512-DdLHq21e93R9qDHyRuRpytBLY0Up9IwNWMOUgPNW6lRSng4N4+IdUlLS3Ekbasmxfs8Z8vKS8aezeYovQ5qsxQ==
+
 "@primer/primitives@7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.8.4.tgz#484486ee47050f18b2e82c33e9df247a5886c82a"
@@ -1407,7 +1443,37 @@
   resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.9.0.tgz#c8a27287488c8308b1715a7d73214629c331544a"
   integrity sha512-ZHHfwB0z0z6nDJp263gyGIClYDy+rl0nwqyi4qhcv3Cxhkmtf+If2KVjr6FQqBBFfi1wQwUzaax2FBvfEMFBnw==
 
-"@primer/react@^35.2.0", "@primer/react@^35.2.1":
+"@primer/react@^35.15.1":
+  version "35.16.0"
+  resolved "https://registry.yarnpkg.com/@primer/react/-/react-35.16.0.tgz#cb625f36e3d3e92b0fc15e5c7645ec34d170011b"
+  integrity sha512-vNm4DXagnWaPVzfJqxOJJb3tJm4MAN9upOMtnE/BmFp5jx+e8N0+EQHzpfb1ngcVrKHQCVP3qA+Ry2iKSGDEJg==
+  dependencies:
+    "@github/combobox-nav" "^2.1.5"
+    "@github/markdown-toolbar-element" "^2.1.0"
+    "@github/paste-markdown" "^1.4.0"
+    "@github/relative-time-element" "4.1.2"
+    "@lit-labs/react" "1.0.9"
+    "@primer/behaviors" "1.3.1"
+    "@primer/octicons-react" "^17.7.0"
+    "@primer/primitives" "7.10.0"
+    "@react-aria/ssr" "^3.1.0"
+    "@styled-system/css" "^5.1.5"
+    "@styled-system/props" "^5.1.5"
+    "@styled-system/theme-get" "^5.1.2"
+    "@types/styled-components" "^5.1.11"
+    "@types/styled-system" "^5.1.12"
+    "@types/styled-system__css" "^5.0.16"
+    "@types/styled-system__theme-get" "^5.0.1"
+    classnames "^2.3.1"
+    color2k "^1.2.4"
+    deepmerge "^4.2.2"
+    focus-visible "^5.2.0"
+    fzy.js "0.4.1"
+    history "^5.0.0"
+    react-intersection-observer "9.4.1"
+    styled-system "^5.1.5"
+
+"@primer/react@^35.2.0":
   version "35.5.0"
   resolved "https://registry.yarnpkg.com/@primer/react/-/react-35.5.0.tgz#b4615786bc8f50cca5b13f83f944ad87a5891c27"
   integrity sha512-jqF3T1c/F0pCjfuGTRfB8QphEC6u9ZR+vao4MZDk1vQN9QiPCep07i6f6ijy9F7kNlhe/IGVz49tQaX5KDxM8w==
@@ -4594,6 +4660,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+fzy.js@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/fzy.js/-/fzy.js-0.4.1.tgz#695bf87cc0bbdda9cbcf22bc318a74c4aca6b758"
+  integrity sha512-4sPVXf+9oGhzg2tYzgWe4hgAY0wEbkqeuKVEgdnqX8S8VcLosQsDjb0jV+f5uoQlf8INWId1w0IGoufAoik1TA==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -6253,6 +6324,11 @@ react-image-annotation@^0.9.10:
   integrity sha512-+g8RXqGoaCXfZfhGPG1MeYSo4Bn5iTwgL8z+Gl4P+j1CFHH9yQGGV6WlgCy8v/FAC6JyQ2ThPwBoj65kSq7j2w==
   dependencies:
     styled-components "^3.1.6"
+
+react-intersection-observer@9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.4.1.tgz#4ccb21e16acd0b9cf5b28d275af7055bef878f6b"
+  integrity sha512-IXpIsPe6BleFOEHKzKh5UjwRUaz/JYS0lT/HPsupWEQou2hDqjhLMStc5zyE3eQVT4Fk3FufM8Fw33qW1uyeiw==
 
 react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
Companion PR to https://github.com/githubnext/blocks-dev/pull/21.

This PR fixes [NEXT-634](https://linear.app/github-next/issue/NEXT-634/infinite-canvas-block-seems-to-have-trouble-finding-files).

There's still an open experiential (and technical question) as to whether the file picker should disclose _all_ of the files in the repository, or only those that are children of the current tree node.

In order to implement the former, I think we'll need an upstream change in `blocks-platform` so that the `tree` prop that gets passed down to folder blocks is always the highest-level tree, rather than the branch that's sliced according to the current `path`.