### PR TITLE
Add ability to paste image to Markdown block

### DIFF
--- a/blocks/file-blocks/markdown-edit/copy-widget.tsx
+++ b/blocks/file-blocks/markdown-edit/copy-widget.tsx
@@ -559,10 +559,8 @@ export const parseImageUrl = (
   url: string,
   context: FileContext | FolderContext
 ) => {
-  if (!url.startsWith("http")) {
-    const pathRoot = context.path.split("/").slice(0, -1).join("/");
-    return `https://raw.githubusercontent.com/${context.owner}/${context.repo}/${context.sha}/${pathRoot}/${url}`;
-  } else {
-    return url;
-  }
+  if (url.startsWith("http")) return url;
+  if (url.startsWith("data:")) return url;
+  const pathRoot = context.path.split("/").slice(0, -1).join("/");
+  return `https://raw.githubusercontent.com/${context.owner}/${context.repo}/${context.sha}/${pathRoot}/${url}`;
 };

--- a/blocks/file-blocks/markdown-edit/extensions.ts
+++ b/blocks/file-blocks/markdown-edit/extensions.ts
@@ -129,7 +129,7 @@ export function makeExtensions({
     EditorView.domEventHandlers({
       paste(e, view) {
         const value = e.clipboardData?.items[0];
-        const MAX_IMAGE_SIZE = 5000000;
+        const MAX_URL_SIZE = 5000000;
         // handle images pasted from the web
         if (value && value.type === "text/html") {
           value.getAsString((str) => {
@@ -142,7 +142,7 @@ export function makeExtensions({
                   from: view.state.selection.main.from,
                   to: view.state.selection.main.to,
                   insert: images
-                    .filter((image) => image && image.length < MAX_IMAGE_SIZE)
+                    .filter((image) => image && image.length < MAX_URL_SIZE)
                     .map((image) => `![${image}](${image})`)
                     .join("\n"),
                 },
@@ -158,7 +158,7 @@ export function makeExtensions({
             const reader = new FileReader();
             reader.onload = (e) => {
               const image = e.target?.result as string;
-              if (image && image.length < MAX_IMAGE_SIZE) {
+              if (image && image.length < MAX_URL_SIZE) {
                 view.dispatch({
                   changes: {
                     from: view.state.selection.main.from,

--- a/blocks/file-blocks/markdown-edit/image-widget.tsx
+++ b/blocks/file-blocks/markdown-edit/image-widget.tsx
@@ -156,10 +156,8 @@ export const parseImageUrl = (
   url: string,
   context: FileContext | FolderContext
 ) => {
-  if (!url.startsWith("http")) {
-    const pathRoot = context.path.split("/").slice(0, -1).join("/");
-    return `https://raw.githubusercontent.com/${context.owner}/${context.repo}/${context.sha}/${pathRoot}/${url}`;
-  } else {
-    return url;
-  }
+  if (url.startsWith("http")) return url;
+  if (url.startsWith("data:")) return url;
+  const pathRoot = context.path.split("/").slice(0, -1).join("/");
+  return `https://raw.githubusercontent.com/${context.owner}/${context.repo}/${context.sha}/${pathRoot}/${url}`;
 };


### PR DESCRIPTION
Listens for a paste event and adds the base64 image string if it contains an image. It's not ideal (clutters up the code with a long string), but I think helpful enough for now!

https://user-images.githubusercontent.com/3506269/212191888-961e8d09-0781-42ee-b543-bdd2674dad8f.mov


