### PR TITLE
Fix Code tour block

### DIFF
--- a/blocks/folder-blocks/code-tour/index.tsx
+++ b/blocks/folder-blocks/code-tour/index.tsx
@@ -1,5 +1,5 @@
 import { tw } from "twind";
-import cq from "@fullstackio/cq";
+import cq from "@fullstackio/cq/dist/cq.browser.js";
 import { FolderBlockProps, getLanguageFromFilename } from "@githubnext/blocks";
 import debounce from "lodash/debounce";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/blocks/folder-blocks/code-tour/index.tsx
+++ b/blocks/folder-blocks/code-tour/index.tsx
@@ -7,6 +7,7 @@ import Select from "react-select";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import "./style.css";
 import { Button, FormControl, TextInput } from "@primer/react";
+import { Buffer } from "buffer";
 
 export default function (props: FolderBlockProps) {
   const {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/lodash.unescape": "^4.0.7",
     "@types/papaparse": "^5.3.1",
     "axios": "^0.26.1",
+    "buffer": "^6.0.3",
     "cssjson": "^2.1.3",
     "d3": "^7.1.1",
     "dompurify": "^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2912,6 +2912,14 @@ buffer@^5.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 bytes@3.1.2, bytes@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -4873,7 +4881,7 @@ iconv-lite@0.6, iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ieee754@^1.1.12, ieee754@^1.1.13:
+ieee754@^1.1.12, ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==


### PR DESCRIPTION
This fixes #79 
- Update cq to use browser package 
- install [buffer](/feross/buffer)